### PR TITLE
feat(scanner): TCP connect fallback when nmap binary missing

### DIFF
--- a/custom_components/homelable/scanner.py
+++ b/custom_components/homelable/scanner.py
@@ -10,12 +10,14 @@ import ipaddress
 import logging
 import os
 import re
+import shutil
 import socket
 import subprocess
 import threading
 from typing import Any
 
 from .fingerprint import fingerprint_ports, suggest_node_type
+from .tcp_scanner import tcp_connect_scan
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,6 +36,8 @@ _EXTRA_PORTS = (
     "16686,34567,37777,51413,64738"
 )
 
+_PORT_LIST: tuple[int, ...] = tuple(int(p) for p in _EXTRA_PORTS.split(","))
+
 _MDNS_SERVICE_TYPES = [
     "_http._tcp.local.",
     "_shelly._tcp.local.",
@@ -46,9 +50,24 @@ _MDNS_SERVICE_TYPES = [
 try:
     import nmap
 
-    _NMAP_AVAILABLE = True
+    _NMAP_LIB_AVAILABLE = True
 except ImportError:
-    _NMAP_AVAILABLE = False
+    _NMAP_LIB_AVAILABLE = False
+
+# python-nmap is a wrapper that shells out to the `nmap` binary. The lib alone
+# is not enough — HA OS ships the lib (we list it in requirements) but not the
+# binary, which is what causes service detection to silently return nothing.
+_NMAP_BINARY_AVAILABLE = shutil.which("nmap") is not None
+_NMAP_AVAILABLE = _NMAP_LIB_AVAILABLE and _NMAP_BINARY_AVAILABLE
+
+if _NMAP_AVAILABLE:
+    _LOGGER.info("Scanner mode: nmap (binary + python-nmap detected)")
+elif _NMAP_LIB_AVAILABLE and not _NMAP_BINARY_AVAILABLE:
+    _LOGGER.info(
+        "Scanner mode: TCP fallback (python-nmap present but nmap binary "
+        "missing — typical on HA OS)"
+    )
+else:
     _LOGGER.warning("python-nmap not available — scanner will run in mock mode")
 
 try:
@@ -196,7 +215,7 @@ async def _ping_sweep(target: str) -> dict[str, dict[str, Any]]:
 
 
 def _nmap_scan_single(host_dict: dict[str, Any]) -> dict[str, Any]:
-    """Phase 2: per-IP service detection. Blocking — call via to_thread."""
+    """Phase 2 (nmap path): per-IP service detection. Blocking — call via to_thread."""
     ip = host_dict["ip"]
     if not _NMAP_AVAILABLE:
         return host_dict
@@ -233,21 +252,31 @@ def _nmap_scan_single(host_dict: dict[str, Any]) -> dict[str, Any]:
     return host_dict
 
 
-async def _nmap_port_scan(
+async def _phase2_port_scan(
     alive: dict[str, dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    """Phase 2: per-IP port scan with bounded concurrency (10 hosts at a time)."""
+    """Phase 2: per-IP port scan with bounded concurrency (10 hosts at a time).
+
+    Dispatches to nmap when the binary is available, falls back to a pure-Python
+    TCP connect scan otherwise. Both paths produce the same host_dict shape.
+    """
     if not alive:
         return []
 
     semaphore = asyncio.Semaphore(10)
 
-    async def _scan_with_sem(host_dict: dict[str, Any]) -> dict[str, Any]:
+    async def _nmap_with_sem(host_dict: dict[str, Any]) -> dict[str, Any]:
         async with semaphore:
             return await asyncio.to_thread(_nmap_scan_single, host_dict)
 
+    async def _tcp_with_sem(host_dict: dict[str, Any]) -> dict[str, Any]:
+        async with semaphore:
+            return await tcp_connect_scan(host_dict, _PORT_LIST)
+
+    runner = _nmap_with_sem if _NMAP_AVAILABLE else _tcp_with_sem
+
     raw = await asyncio.gather(
-        *[_scan_with_sem(h) for h in alive.values()],
+        *[runner(h) for h in alive.values()],
         return_exceptions=True,
     )
     results: list[dict[str, Any]] = []
@@ -260,11 +289,15 @@ async def _nmap_port_scan(
 
 
 async def _nmap_scan(target: str) -> list[dict[str, Any]]:
-    """Two-phase scan for a CIDR range (ping → port scan)."""
-    if not _NMAP_AVAILABLE:
+    """Two-phase scan for a CIDR range (ping → port scan).
+
+    Falls back to a pure-Python TCP connect scan when the nmap binary is
+    missing. Returns mock data only when python-nmap itself is missing.
+    """
+    if not _NMAP_LIB_AVAILABLE:
         return _mock_scan(target)
     alive = await _ping_sweep(target)
-    return await _nmap_port_scan(alive)
+    return await _phase2_port_scan(alive)
 
 
 async def _mdns_discover(timeout: float = 4.0) -> list[dict[str, Any]]:

--- a/custom_components/homelable/tcp_scanner.py
+++ b/custom_components/homelable/tcp_scanner.py
@@ -1,0 +1,180 @@
+"""Pure-Python TCP connect scan + banner grab.
+
+Used as fallback when the `nmap` binary is unavailable (e.g. HA OS, where
+the core container does not ship nmap). Produces the same
+{port, protocol, banner} shape as the nmap path, so fingerprint.py is
+mode-agnostic.
+
+No OS detection, no SYN scan. Open-port detection only, with best-effort
+banner grab. Stdlib only (asyncio, ssl).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import ssl
+from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
+
+# Per-host port concurrency. Outer host concurrency is capped by the caller.
+_PORT_CONCURRENCY = 50
+
+# Default per-port timeouts.
+_CONNECT_TIMEOUT = 1.5
+_BANNER_TIMEOUT = 1.0
+
+# Ports we expect to speak HTTP. We probe these with HEAD and parse Server:.
+_HTTP_PORTS: frozenset[int] = frozenset({
+    80, 3000, 3001, 5000, 5001, 5601, 6789, 6800, 6767, 7878, 8000, 8080,
+    8081, 8086, 8088, 8090, 8096, 8112, 8123, 8200, 8291, 8428, 8686, 8789,
+    8880, 8971, 8989, 9000, 9001, 9090, 9091, 9092, 9093, 9100, 9117, 9200,
+    9300, 9411, 9696, 16686, 34567, 1880,
+})
+
+# Ports that almost always speak TLS.
+_TLS_PORTS: frozenset[int] = frozenset({
+    443, 465, 636, 993, 995, 5601, 6443, 8006, 8443, 8843, 8883, 9443,
+})
+
+# Ports that send a banner immediately on connect (no probe needed).
+_PASSIVE_BANNER_PORTS: frozenset[int] = frozenset({
+    21, 22, 23, 25, 110, 143, 3306, 5432, 6379,
+})
+
+_BANNER_READ_BYTES = 1024
+
+
+def _build_ssl_context() -> ssl.SSLContext:
+    """Permissive context — homelab gear often has self-signed certs."""
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    return ctx
+
+
+_SSL_CONTEXT = _build_ssl_context()
+
+
+def _parse_http_server(payload: bytes) -> str:
+    """Pull the `Server:` header out of an HTTP response. Empty if missing."""
+    try:
+        text = payload.decode("latin-1", errors="replace")
+    except Exception:
+        return ""
+    for line in text.split("\r\n"):
+        if line.lower().startswith("server:"):
+            return line.split(":", 1)[1].strip()
+    return ""
+
+
+async def _grab_http_banner(
+    ip: str, port: int, *, use_tls: bool, timeout: float
+) -> str:
+    """Send HEAD /, return Server header or empty."""
+    try:
+        coro = asyncio.open_connection(
+            ip, port, ssl=_SSL_CONTEXT if use_tls else None
+        )
+        reader, writer = await asyncio.wait_for(coro, timeout=timeout)
+    except (TimeoutError, OSError, ssl.SSLError):
+        return ""
+
+    try:
+        writer.write(
+            f"HEAD / HTTP/1.0\r\nHost: {ip}\r\nUser-Agent: homelable\r\n\r\n".encode()
+        )
+        await asyncio.wait_for(writer.drain(), timeout=timeout)
+        data = await asyncio.wait_for(
+            reader.read(_BANNER_READ_BYTES), timeout=timeout
+        )
+        return _parse_http_server(data)
+    except (TimeoutError, OSError, ssl.SSLError):
+        return ""
+    finally:
+        try:
+            writer.close()
+            await asyncio.wait_for(writer.wait_closed(), timeout=0.5)
+        except (TimeoutError, OSError, ssl.SSLError):
+            pass
+
+
+async def _grab_passive_banner(
+    reader: asyncio.StreamReader, *, timeout: float
+) -> str:
+    """Read whatever the server sends on connect (SSH/FTP/SMTP/etc)."""
+    try:
+        data = await asyncio.wait_for(
+            reader.read(_BANNER_READ_BYTES), timeout=timeout
+        )
+    except (TimeoutError, OSError):
+        return ""
+    return data.decode("latin-1", errors="replace").strip()
+
+
+async def _scan_port(
+    ip: str,
+    port: int,
+    *,
+    connect_timeout: float,
+    banner_timeout: float,
+) -> dict[str, Any] | None:
+    """Probe a single port. Return {port, protocol, banner} if open, else None."""
+    try:
+        coro = asyncio.open_connection(ip, port)
+        reader, writer = await asyncio.wait_for(coro, timeout=connect_timeout)
+    except (TimeoutError, OSError):
+        return None
+
+    banner = ""
+    try:
+        if port in _PASSIVE_BANNER_PORTS:
+            banner = await _grab_passive_banner(reader, timeout=banner_timeout)
+    finally:
+        try:
+            writer.close()
+            await asyncio.wait_for(writer.wait_closed(), timeout=0.5)
+        except (TimeoutError, OSError):
+            pass
+
+    # HTTP / TLS probe is a second connection: keep the open-detection path
+    # cheap, only spend on banner where it pays off.
+    if not banner and (port in _HTTP_PORTS or port in _TLS_PORTS):
+        banner = await _grab_http_banner(
+            ip, port, use_tls=port in _TLS_PORTS, timeout=banner_timeout
+        )
+
+    return {"port": port, "protocol": "tcp", "banner": banner}
+
+
+async def tcp_connect_scan(
+    host: dict[str, Any],
+    ports: tuple[int, ...] | list[int],
+    *,
+    connect_timeout: float = _CONNECT_TIMEOUT,
+    banner_timeout: float = _BANNER_TIMEOUT,
+    port_concurrency: int = _PORT_CONCURRENCY,
+) -> dict[str, Any]:
+    """Scan all `ports` against host['ip']. Mutates and returns the host dict.
+
+    Mirrors the shape produced by scanner._nmap_scan_single so downstream
+    fingerprinting works unchanged. Sets host['open_ports']; leaves 'os' alone.
+    """
+    ip = host["ip"]
+    sem = asyncio.Semaphore(port_concurrency)
+
+    async def _bound(port: int) -> dict[str, Any] | None:
+        async with sem:
+            try:
+                return await _scan_port(
+                    ip, port,
+                    connect_timeout=connect_timeout,
+                    banner_timeout=banner_timeout,
+                )
+            except Exception as exc:  # noqa: BLE001
+                _LOGGER.debug("tcp scan %s:%s failed: %s", ip, port, exc)
+                return None
+
+    results = await asyncio.gather(*[_bound(p) for p in ports])
+    host["open_ports"] = [r for r in results if r is not None]
+    return host

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -128,6 +128,55 @@ async def test_run_scan_cancel_short_circuits() -> None:
     assert devices == []
 
 
+@pytest.mark.asyncio
+async def test_phase2_falls_back_to_tcp_scanner_when_nmap_binary_missing() -> None:
+    """Without the nmap binary, port scan dispatches to tcp_connect_scan."""
+    alive = {
+        "10.0.0.5": {"ip": "10.0.0.5", "hostname": None, "mac": None, "os": None, "open_ports": []},
+    }
+
+    async def _fake_tcp(host: dict, ports: tuple[int, ...]) -> dict:
+        host["open_ports"] = [{"port": 80, "protocol": "tcp", "banner": "nginx"}]
+        return host
+
+    with (
+        patch.object(scanner, "_NMAP_AVAILABLE", False),
+        patch.object(scanner, "tcp_connect_scan", _fake_tcp),
+    ):
+        results = await scanner._phase2_port_scan(alive)
+
+    assert len(results) == 1
+    assert results[0]["open_ports"] == [{"port": 80, "protocol": "tcp", "banner": "nginx"}]
+
+
+@pytest.mark.asyncio
+async def test_phase2_uses_nmap_when_available() -> None:
+    """With nmap available, port scan dispatches to _nmap_scan_single."""
+    alive = {
+        "10.0.0.5": {"ip": "10.0.0.5", "hostname": None, "mac": None, "os": None, "open_ports": []},
+    }
+    tcp_called = False
+
+    async def _fake_tcp(host: dict, ports: tuple[int, ...]) -> dict:
+        nonlocal tcp_called
+        tcp_called = True
+        return host
+
+    def _fake_nmap_single(host: dict) -> dict:
+        host["open_ports"] = [{"port": 22, "protocol": "tcp", "banner": "OpenSSH"}]
+        return host
+
+    with (
+        patch.object(scanner, "_NMAP_AVAILABLE", True),
+        patch.object(scanner, "_nmap_scan_single", _fake_nmap_single),
+        patch.object(scanner, "tcp_connect_scan", _fake_tcp),
+    ):
+        results = await scanner._phase2_port_scan(alive)
+
+    assert tcp_called is False
+    assert results[0]["open_ports"] == [{"port": 22, "protocol": "tcp", "banner": "OpenSSH"}]
+
+
 def test_request_cancel_records_run_id() -> None:
     """request_cancel marks the run_id; _is_cancelled reflects it."""
     scanner.request_cancel("my-run")

--- a/tests/test_tcp_scanner.py
+++ b/tests/test_tcp_scanner.py
@@ -1,0 +1,180 @@
+"""Tests for the pure-Python TCP connect scan fallback.
+
+Real loopback sockets are blocked by pytest-socket inside this test suite,
+so we mock asyncio.open_connection. The interesting logic lives in
+banner-mode dispatch and result shape, both of which mock cleanly.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from custom_components.homelable import tcp_scanner
+
+
+class _FakeReader:
+    def __init__(self, payload: bytes = b"") -> None:
+        self._payload = payload
+        self._consumed = False
+
+    async def read(self, n: int) -> bytes:
+        if self._consumed:
+            return b""
+        self._consumed = True
+        return self._payload[:n]
+
+
+class _FakeWriter:
+    def __init__(self) -> None:
+        self.written: list[bytes] = []
+        self.closed = False
+
+    def write(self, data: bytes) -> None:
+        self.written.append(data)
+
+    async def drain(self) -> None:
+        return None
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        return None
+
+
+def _connect_factory(open_ports: dict[int, bytes], *, tls_payloads: dict[int, bytes] | None = None):
+    """Build a fake asyncio.open_connection. open_ports keyed by port → payload."""
+    tls_payloads = tls_payloads or {}
+
+    async def fake_open(host: str, port: int, *, ssl: Any = None, **_: Any):
+        if ssl is not None:
+            if port in tls_payloads:
+                return _FakeReader(tls_payloads[port]), _FakeWriter()
+            raise OSError("connection refused")
+        if port in open_ports:
+            return _FakeReader(open_ports[port]), _FakeWriter()
+        raise OSError("connection refused")
+
+    return fake_open
+
+
+@pytest.mark.asyncio
+async def test_closed_port_not_returned() -> None:
+    """Connection refused → port omitted from results."""
+    fake = _connect_factory(open_ports={})
+    with patch.object(tcp_scanner.asyncio, "open_connection", fake):
+        result = await tcp_scanner.tcp_connect_scan(
+            {"ip": "10.0.0.1"}, [9999], connect_timeout=0.5, banner_timeout=0.2
+        )
+    assert result["open_ports"] == []
+
+
+@pytest.mark.asyncio
+async def test_passive_banner_captured_for_ssh_port() -> None:
+    """Port 22 is in the passive set; the scanner reads the SSH banner on connect."""
+    fake = _connect_factory(open_ports={22: b"SSH-2.0-OpenSSH_9.6\r\n"})
+    with patch.object(tcp_scanner.asyncio, "open_connection", fake):
+        result = await tcp_scanner.tcp_connect_scan(
+            {"ip": "10.0.0.1"}, [22], connect_timeout=0.5, banner_timeout=0.2
+        )
+    assert len(result["open_ports"]) == 1
+    entry = result["open_ports"][0]
+    assert entry["port"] == 22
+    assert entry["protocol"] == "tcp"
+    assert "SSH-2.0-OpenSSH_9.6" in entry["banner"]
+
+
+@pytest.mark.asyncio
+async def test_http_banner_via_head_request() -> None:
+    """Port 80 triggers a HEAD probe; Server header surfaces in the banner field."""
+    response = b"HTTP/1.0 200 OK\r\nServer: nginx/1.99\r\nContent-Length: 0\r\n\r\n"
+    fake = _connect_factory(open_ports={80: response})
+    with patch.object(tcp_scanner.asyncio, "open_connection", fake):
+        result = await tcp_scanner.tcp_connect_scan(
+            {"ip": "10.0.0.1"}, [80], connect_timeout=0.5, banner_timeout=0.5
+        )
+    assert len(result["open_ports"]) == 1
+    assert result["open_ports"][0]["banner"] == "nginx/1.99"
+
+
+@pytest.mark.asyncio
+async def test_tls_port_uses_ssl_context() -> None:
+    """Port 443 is in the TLS set; the HEAD probe is sent over an SSL connection."""
+    response = b"HTTP/1.0 200 OK\r\nServer: Caddy\r\n\r\n"
+    fake = _connect_factory(open_ports={443: b""}, tls_payloads={443: response})
+    with patch.object(tcp_scanner.asyncio, "open_connection", fake):
+        result = await tcp_scanner.tcp_connect_scan(
+            {"ip": "10.0.0.1"}, [443], connect_timeout=0.5, banner_timeout=0.5
+        )
+    assert len(result["open_ports"]) == 1
+    assert result["open_ports"][0]["banner"] == "Caddy"
+
+
+@pytest.mark.asyncio
+async def test_silent_open_port_reports_empty_banner() -> None:
+    """A port that's open but neither HTTP nor passive returns an empty banner."""
+    fake = _connect_factory(open_ports={64738: b""})  # Mumble port, not in any probe set
+    with patch.object(tcp_scanner.asyncio, "open_connection", fake):
+        result = await tcp_scanner.tcp_connect_scan(
+            {"ip": "10.0.0.1"}, [64738], connect_timeout=0.5, banner_timeout=0.2
+        )
+    assert len(result["open_ports"]) == 1
+    assert result["open_ports"][0]["banner"] == ""
+
+
+@pytest.mark.asyncio
+async def test_mixed_ports_only_open_returned() -> None:
+    """Out of (open, closed, open), only the listening pair survives."""
+    fake = _connect_factory(open_ports={22: b"SSH-2.0-test", 80: b"HTTP/1.0 200 OK\r\nServer: x\r\n\r\n"})
+    with patch.object(tcp_scanner.asyncio, "open_connection", fake):
+        result = await tcp_scanner.tcp_connect_scan(
+            {"ip": "10.0.0.1"}, [22, 9999, 80], connect_timeout=0.5, banner_timeout=0.2
+        )
+    open_set = {p["port"] for p in result["open_ports"]}
+    assert open_set == {22, 80}
+
+
+@pytest.mark.asyncio
+async def test_connect_timeout_treated_as_closed() -> None:
+    """asyncio.TimeoutError on open_connection is swallowed; port omitted."""
+    async def slow_open(*args: Any, **kwargs: Any):
+        await asyncio.sleep(10)
+
+    with patch.object(tcp_scanner.asyncio, "open_connection", slow_open):
+        result = await tcp_scanner.tcp_connect_scan(
+            {"ip": "10.0.0.1"}, [22], connect_timeout=0.05, banner_timeout=0.05
+        )
+    assert result["open_ports"] == []
+
+
+@pytest.mark.asyncio
+async def test_scan_preserves_existing_host_fields() -> None:
+    """Scan mutates open_ports but leaves mac/hostname/os intact."""
+    fake = _connect_factory(open_ports={})
+    host = {"ip": "10.0.0.1", "mac": "AA:BB:CC:DD:EE:FF", "hostname": "x.lan", "os": None}
+    with patch.object(tcp_scanner.asyncio, "open_connection", fake):
+        result = await tcp_scanner.tcp_connect_scan(
+            host, [22], connect_timeout=0.05, banner_timeout=0.05
+        )
+    assert result["mac"] == "AA:BB:CC:DD:EE:FF"
+    assert result["hostname"] == "x.lan"
+    assert result["os"] is None
+    assert result["open_ports"] == []
+
+
+def test_parse_http_server_header() -> None:
+    payload = b"HTTP/1.1 200 OK\r\nServer: Caddy\r\nContent-Type: text/html\r\n\r\n"
+    assert tcp_scanner._parse_http_server(payload) == "Caddy"
+
+
+def test_parse_http_server_missing_header() -> None:
+    payload = b"HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n"
+    assert tcp_scanner._parse_http_server(payload) == ""
+
+
+def test_parse_http_server_undecodable_bytes() -> None:
+    payload = b"\x00\x01\x02non-http-garbage"
+    assert tcp_scanner._parse_http_server(payload) == ""


### PR DESCRIPTION
## Summary

- `python-nmap` is a wrapper around the `nmap` binary. HA OS ships the Python lib (we list it in `requirements`) but **not** the binary, so service detection silently returned empty `open_ports` — every discovered host showed up with ping + ARP info but no services. This is the root cause behind users on HA OS / Proxmox VMs reporting "scan only finds machines, no services".
- Add a pure-Python TCP connect scan fallback (`tcp_scanner.py`) that runs when the binary is missing. Same `{port, protocol, banner}` shape as the nmap path, so `fingerprint.py` and the rest of the pipeline are mode-agnostic.
- Mode is detected at import via `shutil.which("nmap")` and logged once at startup.

## Behavior matrix

| python-nmap | nmap binary | Mode |
|---|---|---|
| ✅ | ✅ | nmap (`-sV -sS/-sT`, OS detection) |
| ✅ | ❌ | **TCP connect fallback (new)** |
| ❌ | — | mock |

## Banner strategy (TCP path)

- **Passive ports** (22, 21, 25, 110, 143, 3306, 5432, 6379…): read on connect, no probe.
- **HTTP ports** (80, 8080, 8123, 3000…): send `HEAD /`, parse `Server:` header.
- **TLS ports** (443, 8443, 6443, 8006…): same HEAD probe over SSL with permissive context (homelab self-signed certs).
- **Silent ports**: connection alone confirms open; banner is empty, fingerprint falls back to port-only match in `service_signatures.json`.

No OS detection, no SYN scan — open-port detection only. Stdlib only (asyncio + ssl), no new deps.

## Concurrency

- Outer host concurrency cap unchanged (`Semaphore(10)`).
- Inner port concurrency capped at `Semaphore(50)` per host.

## Test plan

- [x] `pytest tests/test_tcp_scanner.py` — 11 new tests (closed/open/passive/HTTP/TLS/timeout/preserved fields/parser).
- [x] `pytest tests/test_scanner.py` — 2 new dispatch tests (binary present → nmap path; binary missing → TCP path).
- [x] Full suite: 90/90 green.
- [x] `ruff check` clean.
- [ ] Manual: install on HA OS VM (Proxmox), trigger scan, confirm services populate on discovered hosts.
- [ ] Manual: install on environment with nmap binary present, confirm nmap path still used (look for `Scanner mode: nmap` in logs).

## Out of scope (queued for follow-up PR)

Progressive streaming — phase 1 emits `device_discovered` events, phase 2 emits `device_enriched` per host, frontend fills in services live instead of bulk-update at end. Touched in a separate PR on top of this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)