### PR TITLE
feat(scan): progressive streaming — devices appear as discovered

### DIFF
--- a/custom_components/homelable/const.py
+++ b/custom_components/homelable/const.py
@@ -23,6 +23,11 @@ DEFAULT_SCAN_RANGES = ["192.168.1.0/24"]
 DEFAULT_SCAN_INTERVAL = 3600  # seconds (1h)
 DEFAULT_STATUS_INTERVAL = 60   # seconds
 
+# Dispatcher signal for live scan events (device_discovered / device_enriched
+# / scan_phase / scan_finished / scan_cancelled). Subscribers receive a single
+# dict payload; see websocket.ws_scan_subscribe.
+SCAN_SIGNAL = f"{DOMAIN}_scan_event"
+
 # Frontend panel
 PANEL_URL = "/homelable_files"
 PANEL_TITLE = "Homelable"

--- a/custom_components/homelable/coordinator.py
+++ b/custom_components/homelable/coordinator.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
@@ -20,6 +21,7 @@ from .const import (
     DEFAULT_STATUS_INTERVAL,
     DOMAIN,
     MAX_SCAN_RUNS,
+    SCAN_SIGNAL,
     STORAGE_KEY_CANVAS,
     STORAGE_KEY_PENDING,
     STORAGE_KEY_RUNS,
@@ -292,6 +294,97 @@ class HomelableCoordinator(DataUpdateCoordinator):
             "new_devices": 0,
         }
 
+    async def _handle_scan_event(
+        self, run_id: str, payload: dict[str, Any]
+    ) -> None:
+        """Apply a scanner event to in-memory pending state and broadcast it.
+
+        Mutates the pending dict in place so list_pending and the WS subscriber
+        see consistent state during the scan. Persisted once at scan end via
+        _save_pending — one event-per-host on a /24 would otherwise hammer Store.
+        """
+        event = payload.get("event")
+        device = payload.get("device") or {}
+        ip = device.get("ip")
+
+        # Augment payload with run_id so subscribers can filter overlapping runs.
+        out = {**payload, "run_id": run_id}
+
+        if event == "device_discovered" and ip:
+            pending = await self._get_pending()
+            existing = next(
+                (d for d in pending["devices"] if d.get("ip") == ip),
+                None,
+            )
+            if existing is None:
+                pending["devices"].append(
+                    {
+                        "id": f"pd-{uuid.uuid4().hex[:8]}",
+                        "ip": ip,
+                        "mac": device.get("mac"),
+                        "hostname": device.get("hostname"),
+                        "os": None,
+                        "open_ports": [],
+                        "services": [],
+                        "suggested_type": None,
+                        "discovery_source": device.get("discovery_source"),
+                        "status": "discovering",
+                        "discovered_at": _utc_now_iso(),
+                    }
+                )
+            elif existing.get("status") in ("discovering", "pending"):
+                # Refresh meta if we got better info this run.
+                existing["mac"] = device.get("mac") or existing.get("mac")
+                existing["hostname"] = (
+                    device.get("hostname") or existing.get("hostname")
+                )
+
+        elif event == "device_enriched" and ip:
+            pending = await self._get_pending()
+            existing = next(
+                (d for d in pending["devices"] if d.get("ip") == ip),
+                None,
+            )
+            if existing is None:
+                # mDNS-only path can land here without a prior discovery event
+                # for hosts that didn't answer ping. Create the entry directly.
+                pending["devices"].append(
+                    {
+                        "id": f"pd-{uuid.uuid4().hex[:8]}",
+                        "ip": ip,
+                        "mac": device.get("mac"),
+                        "hostname": device.get("hostname"),
+                        "os": device.get("os"),
+                        "open_ports": device.get("open_ports", []),
+                        "services": device.get("services", []),
+                        "suggested_type": device.get("suggested_type"),
+                        "discovery_source": device.get("discovery_source"),
+                        "status": "pending",
+                        "discovered_at": _utc_now_iso(),
+                    }
+                )
+            elif existing.get("status") in ("discovering", "pending"):
+                existing.update(
+                    {
+                        "mac": device.get("mac") or existing.get("mac"),
+                        "hostname": device.get("hostname") or existing.get("hostname"),
+                        "os": device.get("os") or existing.get("os"),
+                        "open_ports": device.get("open_ports", []),
+                        "services": device.get("services", []),
+                        "suggested_type": device.get("suggested_type"),
+                        "discovery_source": device.get("discovery_source"),
+                        "status": "pending",
+                    }
+                )
+            # Echo the stored device id back so the frontend can reconcile.
+            stored = next(
+                (d for d in pending["devices"] if d.get("ip") == ip), None
+            )
+            if stored is not None:
+                out["device"] = {**device, "id": stored["id"]}
+
+        async_dispatcher_send(self.hass, SCAN_SIGNAL, out)
+
     async def _run_scan_task(
         self,
         run_id: str,
@@ -300,12 +393,24 @@ class HomelableCoordinator(DataUpdateCoordinator):
         started_at: str,
     ) -> None:
         """Background scan body. Records run state, merges into pending store."""
+        async def _on_event(payload: dict[str, Any]) -> None:
+            await self._handle_scan_event(run_id, payload)
+
         try:
             devices = await scanner.run_scan(
-                ranges, run_id=run_id, exclude_ips=exclude
+                ranges,
+                run_id=run_id,
+                exclude_ips=exclude,
+                on_event=_on_event,
             )
         except Exception as exc:  # noqa: BLE001 — record any failure, then exit
             _LOGGER.exception("Scan %s failed", run_id)
+            async_dispatcher_send(
+                self.hass,
+                SCAN_SIGNAL,
+                {"event": "scan_error", "run_id": run_id, "error": str(exc)},
+            )
+            await self._save_pending()
             await self._record_run(
                 {
                     "id": run_id,
@@ -321,29 +426,18 @@ class HomelableCoordinator(DataUpdateCoordinator):
         finally:
             self._scan_run_id = None
 
-        # Re-fetch pending: it may have changed while we scanned.
+        # Streaming events have already mutated the pending store as the scan
+        # ran. Reconcile here as a safety net for hosts that didn't go through
+        # the event path (defensive — should be a no-op in the happy path).
         pending = await self._get_pending()
-        existing_pending_ips = {
-            d["ip"] for d in pending["devices"] if d.get("status") == "pending"
-        }
         now = _utc_now_iso()
+        scanned_ips = {dev["ip"] for dev in devices}
         for dev in devices:
-            if dev["ip"] in existing_pending_ips:
-                for stored in pending["devices"]:
-                    if stored["ip"] == dev["ip"] and stored.get("status") == "pending":
-                        stored.update(
-                            {
-                                "mac": dev.get("mac") or stored.get("mac"),
-                                "hostname": dev.get("hostname") or stored.get("hostname"),
-                                "os": dev.get("os") or stored.get("os"),
-                                "open_ports": dev.get("open_ports", []),
-                                "services": dev.get("services", []),
-                                "suggested_type": dev.get("suggested_type"),
-                                "discovery_source": dev.get("discovery_source"),
-                            }
-                        )
-                        break
-            else:
+            existing = next(
+                (d for d in pending["devices"] if d.get("ip") == dev["ip"]),
+                None,
+            )
+            if existing is None:
                 pending["devices"].append(
                     {
                         "id": f"pd-{uuid.uuid4().hex[:8]}",
@@ -359,6 +453,25 @@ class HomelableCoordinator(DataUpdateCoordinator):
                         "discovered_at": now,
                     }
                 )
+            elif existing.get("status") in ("discovering", "pending"):
+                existing.update(
+                    {
+                        "mac": dev.get("mac") or existing.get("mac"),
+                        "hostname": dev.get("hostname") or existing.get("hostname"),
+                        "os": dev.get("os") or existing.get("os"),
+                        "open_ports": dev.get("open_ports", []),
+                        "services": dev.get("services", []),
+                        "suggested_type": dev.get("suggested_type"),
+                        "discovery_source": dev.get("discovery_source"),
+                        "status": "pending",
+                    }
+                )
+
+        # Promote any leftover `discovering` entries from this scan that we
+        # have data for, and drop ones that never enriched (cancelled mid-run).
+        for d in list(pending["devices"]):
+            if d.get("status") == "discovering" and d["ip"] not in scanned_ips:
+                pending["devices"].remove(d)
 
         await self._save_pending()
         await self._record_run(
@@ -371,6 +484,15 @@ class HomelableCoordinator(DataUpdateCoordinator):
                 "finished_at": _utc_now_iso(),
                 "error": None,
             }
+        )
+        async_dispatcher_send(
+            self.hass,
+            SCAN_SIGNAL,
+            {
+                "event": "scan_finished",
+                "run_id": run_id,
+                "devices_found": len(devices),
+            },
         )
 
     def cancel_scan(self) -> bool:

--- a/custom_components/homelable/scanner.py
+++ b/custom_components/homelable/scanner.py
@@ -14,10 +14,31 @@ import shutil
 import socket
 import subprocess
 import threading
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from .fingerprint import fingerprint_ports, suggest_node_type
 from .tcp_scanner import tcp_connect_scan
+
+# Coroutine the caller can pass to receive incremental scan events. Schema:
+#   {"event": "scan_phase", "phase": "discovery"|"enrichment", "total": int}
+#   {"event": "device_discovered", "device": {ip, mac?, hostname?, discovery_source}}
+#   {"event": "device_enriched",   "device": {ip, ...full enriched dict}}
+# Errors raised inside the callback are caught and logged — they never abort
+# the scan.
+ScanEventCallback = Callable[[dict[str, Any]], Awaitable[None]]
+
+
+async def _safe_emit(
+    on_event: ScanEventCallback | None, payload: dict[str, Any]
+) -> None:
+    """Invoke `on_event` swallowing any error so subscribers can't kill a scan."""
+    if on_event is None:
+        return
+    try:
+        await on_event(payload)
+    except Exception as exc:  # noqa: BLE001
+        _LOGGER.warning("scan event subscriber raised %s: %s", type(exc).__name__, exc)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -168,8 +189,17 @@ def _arp_table_hosts(network: str) -> dict[str, dict[str, Any]]:
         return {}
 
 
-async def _ping_sweep(target: str) -> dict[str, dict[str, Any]]:
-    """Phase 1: Concurrent ICMP ping sweep + ARP cache."""
+async def _ping_sweep(
+    target: str,
+    *,
+    on_host: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Phase 1: Concurrent ICMP ping sweep + ARP cache.
+
+    `on_host` (if provided) is awaited per alive host with its bare host_dict
+    once ping + hostname + ARP have settled. Used to stream `device_discovered`
+    events before phase 2 starts.
+    """
     net = ipaddress.ip_network(target, strict=False)
     all_ips = [str(ip) for ip in net.hosts()]
     _LOGGER.info("[Phase 1] Pinging %d hosts in %s", len(all_ips), target)
@@ -199,17 +229,28 @@ async def _ping_sweep(target: str) -> dict[str, dict[str, Any]]:
     for ip in alive_ips:
         mac = arp_cache.get(ip, {}).get("mac")
         hostname = await asyncio.to_thread(_resolve_hostname, ip)
-        alive[ip] = {
+        host_dict = {
             "ip": ip,
             "mac": mac,
             "hostname": hostname,
             "os": None,
             "open_ports": [],
         }
+        alive[ip] = host_dict
+        if on_host is not None:
+            try:
+                await on_host(host_dict)
+            except Exception as exc:  # noqa: BLE001
+                _LOGGER.warning("[Phase 1] on_host raised: %s", exc)
 
     for ip, host in arp_cache.items():
         if ip not in alive:
             alive[ip] = host
+            if on_host is not None:
+                try:
+                    await on_host(host)
+                except Exception as exc:  # noqa: BLE001
+                    _LOGGER.warning("[Phase 1] on_host raised: %s", exc)
 
     return alive
 
@@ -254,11 +295,16 @@ def _nmap_scan_single(host_dict: dict[str, Any]) -> dict[str, Any]:
 
 async def _phase2_port_scan(
     alive: dict[str, dict[str, Any]],
+    *,
+    on_host_done: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
 ) -> list[dict[str, Any]]:
     """Phase 2: per-IP port scan with bounded concurrency (10 hosts at a time).
 
     Dispatches to nmap when the binary is available, falls back to a pure-Python
     TCP connect scan otherwise. Both paths produce the same host_dict shape.
+
+    `on_host_done` (if provided) is awaited per host as soon as that host's
+    scan completes — the caller uses this to stream `device_enriched` events.
     """
     if not alive:
         return []
@@ -275,8 +321,17 @@ async def _phase2_port_scan(
 
     runner = _nmap_with_sem if _NMAP_AVAILABLE else _tcp_with_sem
 
+    async def _scan_and_notify(host_dict: dict[str, Any]) -> dict[str, Any]:
+        result = await runner(host_dict)
+        if on_host_done is not None:
+            try:
+                await on_host_done(result)
+            except Exception as exc:  # noqa: BLE001
+                _LOGGER.warning("[Phase 2] on_host_done raised: %s", exc)
+        return result
+
     raw = await asyncio.gather(
-        *[runner(h) for h in alive.values()],
+        *[_scan_and_notify(h) for h in alive.values()],
         return_exceptions=True,
     )
     results: list[dict[str, Any]] = []
@@ -288,7 +343,12 @@ async def _phase2_port_scan(
     return results
 
 
-async def _nmap_scan(target: str) -> list[dict[str, Any]]:
+async def _nmap_scan(
+    target: str,
+    *,
+    on_phase1_host: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
+    on_phase2_host: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
+) -> list[dict[str, Any]]:
     """Two-phase scan for a CIDR range (ping → port scan).
 
     Falls back to a pure-Python TCP connect scan when the nmap binary is
@@ -296,8 +356,8 @@ async def _nmap_scan(target: str) -> list[dict[str, Any]]:
     """
     if not _NMAP_LIB_AVAILABLE:
         return _mock_scan(target)
-    alive = await _ping_sweep(target)
-    return await _phase2_port_scan(alive)
+    alive = await _ping_sweep(target, on_host=on_phase1_host)
+    return await _phase2_port_scan(alive, on_host_done=on_phase2_host)
 
 
 async def _mdns_discover(timeout: float = 4.0) -> list[dict[str, Any]]:
@@ -389,6 +449,7 @@ async def run_scan(
     run_id: str | None = None,
     *,
     exclude_ips: set[str] | None = None,
+    on_event: ScanEventCallback | None = None,
 ) -> list[dict[str, Any]]:
     """Execute a scan for the given CIDR ranges.
 
@@ -402,6 +463,9 @@ async def run_scan(
         ranges: list of CIDR strings (e.g., ["192.168.1.0/24"]).
         run_id: optional cancellation token; pair with `request_cancel(run_id)`.
         exclude_ips: IPs to skip (e.g., already on canvas or hidden by user).
+        on_event: optional async callback invoked with progressive scan events
+            (`device_discovered`, `device_enriched`, `scan_phase`). Subscribers
+            crashing won't abort the scan.
 
     Raises:
         ValueError: if any range is not a valid CIDR.
@@ -416,20 +480,62 @@ async def run_scan(
     devices: list[dict[str, Any]] = []
     seen_ips: set[str] = set()
 
+    async def _emit_phase1(host: dict[str, Any]) -> None:
+        ip = host.get("ip")
+        if not ip or ip in exclude_ips or ip in seen_ips:
+            return
+        seen_ips.add(ip)
+        await _safe_emit(
+            on_event,
+            {
+                "event": "device_discovered",
+                "device": {
+                    "ip": ip,
+                    "mac": host.get("mac"),
+                    "hostname": host.get("hostname"),
+                    "discovery_source": "nmap",
+                },
+            },
+        )
+
+    async def _emit_phase2(host: dict[str, Any]) -> None:
+        ip = host.get("ip")
+        if not ip:
+            return
+        # Honor exclude_ips even on the enrichment side (defensive — phase 1
+        # already gated, but a host could enter via the ARP-only path).
+        if ip in exclude_ips:
+            return
+        await _safe_emit(
+            on_event,
+            {
+                "event": "device_enriched",
+                "device": _enrich(host, discovery_source="nmap"),
+            },
+        )
+
     mdns_task: asyncio.Task[list[dict[str, Any]]] | None = None
     try:
         mdns_task = asyncio.create_task(_mdns_discover())
 
+        await _safe_emit(on_event, {"event": "scan_phase", "phase": "discovery"})
+
         for cidr in ranges:
             if _is_cancelled(run_id):
                 break
-            hosts = await _nmap_scan(cidr)
+            hosts = await _nmap_scan(
+                cidr,
+                on_phase1_host=_emit_phase1,
+                on_phase2_host=_emit_phase2,
+            )
             for host in hosts:
                 if _is_cancelled(run_id):
                     break
                 ip = host["ip"]
-                if ip in exclude_ips or ip in seen_ips:
+                if ip in exclude_ips:
                     continue
+                # seen_ips was populated by _emit_phase1 above; for hosts that
+                # only came through the ARP fallback (no ping), add now.
                 seen_ips.add(ip)
                 devices.append(_enrich(host, discovery_source="nmap"))
 
@@ -442,9 +548,36 @@ async def run_scan(
                 if ip in exclude_ips or ip in seen_ips:
                     continue
                 seen_ips.add(ip)
-                devices.append(_enrich(host, discovery_source="mdns"))
+                enriched = _enrich(host, discovery_source="mdns")
+                devices.append(enriched)
+                # mDNS is single-shot: emit discovery + enrichment together so
+                # the UI gets a fully populated card in one frame.
+                await _safe_emit(
+                    on_event,
+                    {
+                        "event": "device_discovered",
+                        "device": {
+                            "ip": ip,
+                            "mac": host.get("mac"),
+                            "hostname": host.get("hostname"),
+                            "discovery_source": "mdns",
+                        },
+                    },
+                )
+                await _safe_emit(
+                    on_event, {"event": "device_enriched", "device": enriched}
+                )
         elif mdns_task and not mdns_task.done():
             mdns_task.cancel()
+
+        await _safe_emit(
+            on_event,
+            {
+                "event": "scan_finished",
+                "devices_found": len(devices),
+                "cancelled": _is_cancelled(run_id),
+            },
+        )
 
         return devices
     finally:

--- a/custom_components/homelable/websocket.py
+++ b/custom_components/homelable/websocket.py
@@ -6,8 +6,9 @@ from typing import Any
 import voluptuous as vol
 from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from .const import DOMAIN
+from .const import DOMAIN, SCAN_SIGNAL
 
 
 @callback
@@ -25,6 +26,7 @@ def async_register_websocket_commands(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, ws_scan_clear)
     websocket_api.async_register_command(hass, ws_status_get)
     websocket_api.async_register_command(hass, ws_status_subscribe)
+    websocket_api.async_register_command(hass, ws_scan_subscribe)
 
 
 def _coordinator(hass: HomeAssistant):
@@ -245,3 +247,25 @@ def ws_status_subscribe(
     # Send the current snapshot so the client doesn't have to wait for the
     # next coordinator tick to populate.
     _push()
+
+
+@websocket_api.websocket_command(
+    {vol.Required("type"): "homelable/scan/subscribe"}
+)
+@callback
+def ws_scan_subscribe(
+    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
+) -> None:
+    """Stream live scan events (device_discovered / device_enriched / phase / finished)."""
+    coord = _coordinator(hass)
+    if coord is None:
+        _send_not_setup(connection, msg["id"])
+        return
+
+    @callback
+    def _forward(payload: dict[str, Any]) -> None:
+        connection.send_message(websocket_api.event_message(msg["id"], payload))
+
+    unsub = async_dispatcher_connect(hass, SCAN_SIGNAL, _forward)
+    connection.subscriptions[msg["id"]] = unsub
+    connection.send_result(msg["id"])

--- a/frontend-src/src/api/ha.ts
+++ b/frontend-src/src/api/ha.ts
@@ -158,6 +158,45 @@ export async function subscribeStatus(
   return wsSubscribe<StatusUpdate>('homelable/status/subscribe', cb)
 }
 
+// ─── Scan event subscription (progressive scan) ─────────────────────────────
+
+export type ScanEvent =
+  | {
+      event: 'device_discovered'
+      run_id?: string
+      device: {
+        id?: string
+        ip: string
+        mac: string | null
+        hostname: string | null
+        discovery_source?: string | null
+      }
+    }
+  | {
+      event: 'device_enriched'
+      run_id?: string
+      device: {
+        id?: string
+        ip: string
+        mac: string | null
+        hostname: string | null
+        os: string | null
+        open_ports: Array<{ port: number; protocol: string; banner?: string }>
+        services: object[]
+        suggested_type: string | null
+        discovery_source?: string | null
+      }
+    }
+  | { event: 'scan_phase'; run_id?: string; phase: string }
+  | { event: 'scan_finished'; run_id?: string; devices_found: number; cancelled?: boolean }
+  | { event: 'scan_error'; run_id?: string; error: string }
+
+export async function subscribeScan(
+  cb: (event: ScanEvent) => void
+): Promise<() => void> {
+  return wsSubscribe<ScanEvent>('homelable/scan/subscribe', cb)
+}
+
 // Re-export base `api` shim for any direct references; calls here go nowhere.
 export const api = {
   get: async (_url: string) =>

--- a/frontend-src/src/components/panels/Sidebar.tsx
+++ b/frontend-src/src/components/panels/Sidebar.tsx
@@ -3,7 +3,7 @@ import { Plus, Save, ScanLine, ChevronLeft, ChevronRight, LayoutDashboard, Clock
 import { Logo } from '@/components/ui/Logo'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useCanvasStore } from '@/stores/canvasStore'
-import { scanApi } from '@/api/client'
+import { scanApi, subscribeScan, type ScanEvent } from '@/api/client'
 import { toast } from 'sonner'
 import { useLatestRelease } from '@/hooks/useLatestRelease'
 
@@ -254,6 +254,67 @@ function PendingDevicesPanel({ onNodeApproved, highlightId }: { onNodeApproved: 
     if (scanEventTs > 0) load()
   }, [scanEventTs, load])
 
+  // Live scan subscription — patch the pending list as events arrive so the
+  // user sees devices appear with just an IP, then fill in services/hostname
+  // as enrichment finishes per host.
+  useEffect(() => {
+    let unsub: (() => void) | null = null
+    let cancelled = false
+    subscribeScan((event: ScanEvent) => {
+      if (event.event === 'device_discovered') {
+        const { ip, mac, hostname } = event.device
+        setDevices((prev) => {
+          if (prev.some((d) => d.ip === ip)) return prev
+          const placeholder: PendingDevice = {
+            id: `discovering:${ip}`,
+            ip,
+            mac,
+            hostname,
+            os: null,
+            services: [],
+            suggested_type: null,
+            status: 'discovering',
+            discovery_source: event.device.discovery_source ?? null,
+            discovered_at: new Date().toISOString(),
+          }
+          return [placeholder, ...prev]
+        })
+      } else if (event.event === 'device_enriched') {
+        const dev = event.device
+        setDevices((prev) => {
+          const idx = prev.findIndex((d) => d.ip === dev.ip)
+          const enriched: PendingDevice = {
+            id: dev.id ?? prev[idx]?.id ?? `pd-${dev.ip}`,
+            ip: dev.ip,
+            mac: dev.mac,
+            hostname: dev.hostname,
+            os: dev.os,
+            services: (dev.services ?? []) as PendingDevice['services'],
+            suggested_type: dev.suggested_type,
+            status: 'pending',
+            discovery_source: dev.discovery_source ?? null,
+            discovered_at: prev[idx]?.discovered_at ?? new Date().toISOString(),
+          }
+          if (idx === -1) return [enriched, ...prev]
+          const next = [...prev]
+          next[idx] = enriched
+          return next
+        })
+      } else if (event.event === 'scan_finished') {
+        // Reconcile with the source of truth — discovering placeholders that
+        // never enriched are cleaned up server-side, so just refetch.
+        load()
+      }
+    }).then((u) => {
+      if (cancelled) u()
+      else unsub = u
+    })
+    return () => {
+      cancelled = true
+      if (unsub) unsub()
+    }
+  }, [load])
+
   useEffect(() => {
     if (!highlightId || loading) return
     highlightRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
@@ -371,22 +432,28 @@ function PendingDevicesPanel({ onNodeApproved, highlightId }: { onNodeApproved: 
           const sourceColor = d.discovery_source === 'mdns' ? '#a855f7' : '#8b949e'
           const sourceLabel = d.discovery_source === 'mdns' ? 'mDNS' : d.discovery_source === 'arp' ? 'ARP' : null
           const isHighlighted = d.id === highlightId
+          const isDiscovering = d.status === 'discovering'
           return (
             <button
               key={d.id}
               ref={isHighlighted ? highlightRef : null}
-              onClick={() => setSelected(d)}
-              className={`w-full mb-1.5 p-2 rounded-md text-xs text-left transition-colors border ${isHighlighted ? 'bg-[#2d3748] border-[#e3b341]' : checkedIds.has(d.id) ? 'bg-[#21262d] border-[#00d4ff]/40' : 'bg-[#21262d] border-transparent hover:bg-[#30363d] hover:border-[#30363d]'}`}
+              onClick={() => { if (!isDiscovering) setSelected(d) }}
+              disabled={isDiscovering}
+              className={`w-full mb-1.5 p-2 rounded-md text-xs text-left transition-colors border ${isHighlighted ? 'bg-[#2d3748] border-[#e3b341]' : checkedIds.has(d.id) ? 'bg-[#21262d] border-[#00d4ff]/40' : 'bg-[#21262d] border-transparent hover:bg-[#30363d] hover:border-[#30363d]'} ${isDiscovering ? 'opacity-60 cursor-progress animate-pulse' : ''}`}
             >
               <div className="flex items-center gap-1.5">
                 <input
                   type="checkbox"
                   checked={checkedIds.has(d.id)}
+                  disabled={isDiscovering}
                   onClick={(e) => e.stopPropagation()}
                   onChange={(e) => { e.stopPropagation(); toggleCheck(d.id, e as unknown as React.MouseEvent) }}
-                  className="w-3 h-3 accent-[#00d4ff] cursor-pointer shrink-0"
+                  className="w-3 h-3 accent-[#00d4ff] cursor-pointer shrink-0 disabled:cursor-not-allowed"
                 />
                 <span className="text-foreground truncate font-medium">{title}</span>
+                {isDiscovering && (
+                  <Loader2 size={10} className="animate-spin text-muted-foreground shrink-0" />
+                )}
               </div>
               {showIpBelow && (
                 <div className="font-mono text-muted-foreground truncate pl-3 text-[10px] mt-0.5">{d.ip}</div>

--- a/frontend-src/src/components/panels/__tests__/Sidebar.test.tsx
+++ b/frontend-src/src/components/panels/__tests__/Sidebar.test.tsx
@@ -26,6 +26,7 @@ vi.mock('@/api/client', () => ({
     bulkApprove: (...args: unknown[]) => mockBulkApprove(...args),
     bulkHide: (...args: unknown[]) => mockBulkHide(...args),
   },
+  subscribeScan: vi.fn().mockResolvedValue(() => {}),
 }))
 
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
@@ -349,5 +350,53 @@ describe('PendingDevicesPanel — bulk select', () => {
     fireEvent.click(screen.getByText(/Hide \(2\)/))
     await waitFor(() => expect(mockBulkHide).toHaveBeenCalledWith(['dev-a', 'dev-b']))
     await waitFor(() => expect(screen.queryByText('host-b')).not.toBeInTheDocument())
+  })
+})
+
+describe('PendingDevicesPanel — live scan stream', () => {
+  beforeEach(() => {
+    mockStore()
+    vi.clearAllMocks()
+  })
+
+  async function renderEmpty() {
+    const { scanApi } = await import('@/api/client')
+    vi.mocked(scanApi.pending).mockResolvedValue({ data: [] } as never)
+    render(<Sidebar {...defaultProps} forceView="pending" />)
+    await waitFor(() => expect(screen.getByText('No pending devices')).toBeInTheDocument())
+  }
+
+  it('inserts a discovering placeholder on device_discovered then enriches it on device_enriched', async () => {
+    let handler: ((e: unknown) => void) | null = null
+    const { subscribeScan } = await import('@/api/client')
+    vi.mocked(subscribeScan).mockImplementation(async (cb) => {
+      handler = cb as (e: unknown) => void
+      return () => {}
+    })
+
+    await renderEmpty()
+    await waitFor(() => expect(handler).not.toBeNull())
+
+    handler!({
+      event: 'device_discovered',
+      device: { ip: '10.0.0.42', mac: null, hostname: null, discovery_source: 'nmap' },
+    })
+    await waitFor(() => expect(screen.getByText('10.0.0.42')).toBeInTheDocument())
+
+    handler!({
+      event: 'device_enriched',
+      device: {
+        id: 'pd-real',
+        ip: '10.0.0.42',
+        mac: 'AA:BB:CC:DD:EE:FF',
+        hostname: 'host.lan',
+        os: null,
+        services: [],
+        suggested_type: 'generic',
+        discovery_source: 'nmap',
+        open_ports: [],
+      },
+    })
+    await waitFor(() => expect(screen.getByText('host.lan')).toBeInTheDocument())
   })
 })

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -88,7 +88,7 @@ async def test_trigger_scan_excludes_canvas_and_hidden(coord) -> None:  # noqa: 
 
     captured: dict = {}
 
-    async def _fake(ranges, run_id=None, *, exclude_ips=None):
+    async def _fake(ranges, run_id=None, *, exclude_ips=None, on_event=None):
         captured["exclude"] = exclude_ips
         return []
 
@@ -100,6 +100,107 @@ async def test_trigger_scan_excludes_canvas_and_hidden(coord) -> None:  # noqa: 
 
     assert "192.168.1.1" in captured["exclude"]
     assert "192.168.1.99" in captured["exclude"]
+
+
+@pytest.mark.asyncio
+async def test_streaming_events_create_then_enrich_pending(coord) -> None:  # noqa: ANN001
+    """device_discovered → 'discovering' entry; device_enriched → 'pending' with services."""
+    captured_events: list[dict] = []
+
+    from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+    from custom_components.homelable.const import SCAN_SIGNAL
+
+    unsub = async_dispatcher_connect(
+        coord.hass, SCAN_SIGNAL, lambda p: captured_events.append(p)
+    )
+
+    async def _fake(ranges, run_id=None, *, exclude_ips=None, on_event=None):
+        await on_event(
+            {
+                "event": "device_discovered",
+                "device": {"ip": "10.0.0.7", "mac": None, "hostname": None},
+            }
+        )
+        # Mid-scan: pending must already reflect the discovery.
+        mid = await coord.list_pending(status="discovering")
+        assert any(d["ip"] == "10.0.0.7" for d in mid)
+        await on_event(
+            {
+                "event": "device_enriched",
+                "device": {
+                    "ip": "10.0.0.7",
+                    "mac": "AA:BB:CC:DD:EE:FF",
+                    "hostname": "host.lan",
+                    "os": None,
+                    "open_ports": [{"port": 22, "protocol": "tcp", "banner": "OpenSSH"}],
+                    "services": [{"port": 22, "name": "ssh"}],
+                    "suggested_type": "generic",
+                    "discovery_source": "nmap",
+                },
+            }
+        )
+        return [
+            {
+                "ip": "10.0.0.7",
+                "mac": "AA:BB:CC:DD:EE:FF",
+                "hostname": "host.lan",
+                "os": None,
+                "open_ports": [{"port": 22, "protocol": "tcp", "banner": "OpenSSH"}],
+                "services": [{"port": 22, "name": "ssh"}],
+                "suggested_type": "generic",
+                "discovery_source": "nmap",
+            }
+        ]
+
+    with patch(
+        "custom_components.homelable.coordinator.scanner.run_scan", _fake
+    ):
+        await coord.trigger_scan()
+        await coord.hass.async_block_till_done()
+
+    unsub()
+
+    pending = await coord.list_pending()
+    assert len(pending) == 1
+    assert pending[0]["ip"] == "10.0.0.7"
+    assert pending[0]["status"] == "pending"
+    assert pending[0]["mac"] == "AA:BB:CC:DD:EE:FF"
+    assert pending[0]["services"] == [{"port": 22, "name": "ssh"}]
+
+    discovered = [e for e in captured_events if e.get("event") == "device_discovered"]
+    enriched = [e for e in captured_events if e.get("event") == "device_enriched"]
+    finished = [e for e in captured_events if e.get("event") == "scan_finished"]
+    assert len(discovered) == 1
+    assert len(enriched) == 1
+    assert len(finished) == 1
+    assert enriched[0]["device"]["ip"] == "10.0.0.7"
+    # Coordinator echoes the stored device id back so the frontend can reconcile.
+    assert enriched[0]["device"]["id"] == pending[0]["id"]
+
+
+@pytest.mark.asyncio
+async def test_streaming_discovering_entry_dropped_when_never_enriched(coord) -> None:  # noqa: ANN001
+    """If a host was discovered but never enriched (e.g. cancelled), drop it at scan end."""
+    async def _fake(ranges, run_id=None, *, exclude_ips=None, on_event=None):
+        await on_event(
+            {
+                "event": "device_discovered",
+                "device": {"ip": "10.0.0.99"},
+            }
+        )
+        return []  # No enrichment
+
+    with patch(
+        "custom_components.homelable.coordinator.scanner.run_scan", _fake
+    ):
+        await coord.trigger_scan()
+        await coord.hass.async_block_till_done()
+
+    pending = await coord.list_pending(status="discovering")
+    assert pending == []
+    pending_done = await coord.list_pending()
+    assert pending_done == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -17,7 +17,7 @@ async def test_run_scan_invalid_cidr_raises() -> None:
 async def test_run_scan_returns_enriched_devices() -> None:
     """Scan output carries services + suggested_type + discovery_source."""
 
-    async def _fake_nmap(target: str) -> list[dict]:
+    async def _fake_nmap(target: str, **_kwargs) -> list[dict]:
         return [
             {
                 "ip": "10.0.0.5",
@@ -49,7 +49,7 @@ async def test_run_scan_returns_enriched_devices() -> None:
 async def test_run_scan_excludes_ips() -> None:
     """IPs in exclude_ips are skipped."""
 
-    async def _fake_nmap(target: str) -> list[dict]:
+    async def _fake_nmap(target: str, **_kwargs) -> list[dict]:
         return [
             {"ip": "10.0.0.5", "hostname": None, "mac": None, "os": None, "open_ports": []},
             {"ip": "10.0.0.6", "hostname": None, "mac": None, "os": None, "open_ports": []},
@@ -73,7 +73,7 @@ async def test_run_scan_excludes_ips() -> None:
 async def test_run_scan_dedups_across_sources() -> None:
     """Same IP from nmap + mdns surfaces once (nmap wins)."""
 
-    async def _fake_nmap(target: str) -> list[dict]:
+    async def _fake_nmap(target: str, **_kwargs) -> list[dict]:
         return [
             {
                 "ip": "10.0.0.7",
@@ -110,7 +110,7 @@ async def test_run_scan_dedups_across_sources() -> None:
 async def test_run_scan_cancel_short_circuits() -> None:
     """Cancelling a run_id prevents further hosts from being processed."""
 
-    async def _fake_nmap(target: str) -> list[dict]:
+    async def _fake_nmap(target: str, **_kwargs) -> list[dict]:
         scanner.request_cancel("test-run")
         return [
             {"ip": "10.0.0.5", "hostname": None, "mac": None, "os": None, "open_ports": []}

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -267,6 +267,30 @@ async def test_status_subscribe_pushes_initial_snapshot(
     assert snapshot["event"] == {"n1": {"status": "online"}}
 
 
+async def test_scan_subscribe_forwards_dispatcher_events(
+    hass: HomeAssistant, hass_ws_client, setup_ws  # noqa: ANN001
+) -> None:
+    """Events fired on SCAN_SIGNAL reach the subscribed WS client."""
+    from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+    from custom_components.homelable.const import SCAN_SIGNAL
+
+    client = await hass_ws_client(hass)
+    await client.send_json({"id": 1, "type": "homelable/scan/subscribe"})
+    ack = await client.receive_json()
+    assert ack["success"] is True
+
+    payload = {
+        "event": "device_discovered",
+        "run_id": "r-1",
+        "device": {"ip": "10.0.0.5", "mac": None, "hostname": None},
+    }
+    async_dispatcher_send(hass, SCAN_SIGNAL, payload)
+    msg = await client.receive_json()
+    assert msg["type"] == "event"
+    assert msg["event"] == payload
+
+
 # ─── Not setup ───────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Replace bulk-update-at-end scan with per-host streaming so the panel shows ghost cards as soon as phase 1 finishes for a host (ping + ARP + hostname), then fills in services as phase 2 enrichment lands. Big UX win on /24 networks where the scan can take 60s+.

Builds on PR #1 (TCP fallback) — works identically for both the nmap path and the pure-Python TCP path.

## Event protocol

New WS command \`homelable/scan/subscribe\` (mirrors \`homelable/status/subscribe\`). Subscribers receive:

- \`{event: "scan_phase", phase: "discovery"}\` — start of phase 1
- \`{event: "device_discovered", device: {ip, mac?, hostname?, discovery_source}}\` — per host as phase 1 finds it
- \`{event: "device_enriched", device: {ip, mac, hostname, os, open_ports, services, suggested_type, ...}}\` — per host as phase 2 finishes (id echoed back so frontend reconciles)
- \`{event: "scan_finished", devices_found, cancelled?}\`
- \`{event: "scan_error", error}\` (rare path)

## Pending lifecycle

| Status | When | UI |
|---|---|---|
| \`discovering\` | After \`device_discovered\` | Pulse + spinner + approve/hide disabled |
| \`pending\` | After \`device_enriched\` | Normal card |
| \`hidden\` | User action | (unchanged) |

\`discovering\` entries that never enrich (e.g. cancelled mid-run) are dropped at scan end.

## Backend

- \`scanner.run_scan(..., on_event=callback)\` — new optional async callback. Phase 1 emits one event per alive host once \`{ip, mac, hostname}\` is settled; phase 2 emits per host as each port scan completes (both nmap and TCP paths). mDNS-only hosts get discovered+enriched in one frame.
- \`coordinator._handle_scan_event\` — wires events to (a) in-memory pending Store mutation by IP, (b) \`async_dispatcher_send(SCAN_SIGNAL, ...)\`. Single \`async_save\` at scan end avoids hammering disk on a /24.
- \`websocket.ws_scan_subscribe\` — bridges the dispatcher signal to WS clients via \`async_dispatcher_connect\`.

## Frontend

- \`subscribeScan\` + \`ScanEvent\` type in \`api/ha.ts\`.
- \`PendingDevicesPanel\` subscribes on mount; reducer handles all event types. Reload on \`scan_finished\` as a safety-net reconcile.
- Discovering rows: opacity-60 + animate-pulse + tiny spinner; click and bulk-select disabled.

## Test plan

- [x] \`pytest\` — 93/93 (3 new: coordinator streaming flow, discovering cleanup, WS dispatcher forwarding).
- [x] \`ruff check\` — clean.
- [x] \`vitest\` — 767/767 (1 new: reducer transitions discovering → pending by IP).
- [x] \`npm run build:ha\` — clean build.
- [ ] Manual: HA OS on Proxmox VM — observe ghost cards appear as ping completes, then services populate live as TCP scan finishes per host.
- [ ] Manual: cancel mid-scan — discovering entries should disappear after \`scan_finished\` reload.

## Notes

- TS \`tsc -b\` reports 5 pre-existing errors in Sidebar.tsx + 2 in vite.config.ts. Those existed before this PR (verified with stash + clean build); not introduced here.
- One sidebar test file needed \`subscribeScan: vi.fn().mockResolvedValue(() => {})\` added to its \`@/api/client\` mock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)