### PR TITLE
fix(manifest): declare zeroconf as after_dependencies

### DIFF
--- a/custom_components/homelable/manifest.json
+++ b/custom_components/homelable/manifest.json
@@ -3,6 +3,7 @@
   "name": "Homelable",
   "codeowners": ["@Pouzor"],
   "config_flow": true,
+  "after_dependencies": ["zeroconf"],
   "dependencies": [
     "frontend",
     "http",


### PR DESCRIPTION
## Bug

Validate workflow red since PR #3:

\`\`\`
[ERROR] [DEPENDENCIES] Using component zeroconf but it's not in 'dependencies' or 'after_dependencies'
\`\`\`

PR #3 imports \`homeassistant.components.zeroconf\` for the shared instance but didn't declare it.

## Fix

Add \`after_dependencies: [\"zeroconf\"]\` (not \`dependencies\`) — we use the shared instance opportunistically with a fallback, so HA doesn't need to set it up before homelable. \`dependencies\` would force HA to set zeroconf up during config-flow tests, which pytest-socket blocks.

## Test plan

- [x] \`pytest\` 93/93 (would fail with \`dependencies\` due to socket block during zeroconf setup)
- [x] hassfest accepts \`after_dependencies\` as a valid declaration

🤖 Generated with [Claude Code](https://claude.com/claude-code)