### PR TITLE
feat(scanner): drop nmap path, TCP-only scanner

### DIFF
--- a/custom_components/homelable/coordinator.py
+++ b/custom_components/homelable/coordinator.py
@@ -382,12 +382,6 @@ class HomelableCoordinator(DataUpdateCoordinator):
             )
             if stored is not None:
                 out["device"] = {**device, "id": stored["id"]}
-                _LOGGER.info(
-                    "[trace] handle_scan_event enriched ip=%s stored_services=%d status=%s",
-                    ip,
-                    len(stored.get("services", [])),
-                    stored.get("status"),
-                )
 
         async_dispatcher_send(self.hass, SCAN_SIGNAL, out)
 
@@ -476,28 +470,9 @@ class HomelableCoordinator(DataUpdateCoordinator):
 
         # Promote any leftover `discovering` entries from this scan that we
         # have data for, and drop ones that never enriched (cancelled mid-run).
-        dropped = 0
         for d in list(pending["devices"]):
             if d.get("status") == "discovering" and d["ip"] not in scanned_ips:
                 pending["devices"].remove(d)
-                dropped += 1
-
-        pending_count = sum(
-            1 for d in pending["devices"] if d.get("status") == "pending"
-        )
-        services_total = sum(
-            len(d.get("services", []))
-            for d in pending["devices"]
-            if d.get("status") == "pending"
-        )
-        _LOGGER.info(
-            "[trace] scan_done devices_returned=%d pending_in_store=%d "
-            "services_total=%d discovering_dropped=%d",
-            len(devices),
-            pending_count,
-            services_total,
-            dropped,
-        )
 
         await self._save_pending()
         await self._record_run(

--- a/custom_components/homelable/manifest.json
+++ b/custom_components/homelable/manifest.json
@@ -13,8 +13,6 @@
   "integration_type": "service",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/Pouzor/homelable-hacs/issues",
-  "requirements": [
-    "python-nmap>=0.7.1"
-  ],
+  "requirements": [],
   "version": "0.1.5"
 }

--- a/custom_components/homelable/scanner.py
+++ b/custom_components/homelable/scanner.py
@@ -1,16 +1,20 @@
-"""Network scanner: ping sweep + ARP cache + nmap service detection + mDNS discovery.
+"""Network scanner: ping sweep + ARP cache + TCP service detection + mDNS discovery.
 
 HA-adapted: pure scan logic, returns device dicts. No DB, no persistence.
 The caller (coordinator) is responsible for filtering, dedup, and storage.
+
+Phase 2 service detection runs through a pure-Python TCP connect scan. We
+previously had an nmap path too, but it proved unreliable on HA OS (nmap
+binary present but python-nmap parsed empty output) so it was removed —
+the TCP path is deterministic and works on every install without root or
+external binaries.
 """
 from __future__ import annotations
 
 import asyncio
 import ipaddress
 import logging
-import os
 import re
-import shutil
 import socket
 import subprocess
 import threading
@@ -69,29 +73,6 @@ _MDNS_SERVICE_TYPES = [
 ]
 
 try:
-    import nmap
-
-    _NMAP_LIB_AVAILABLE = True
-except ImportError:
-    _NMAP_LIB_AVAILABLE = False
-
-# python-nmap is a wrapper that shells out to the `nmap` binary. The lib alone
-# is not enough — HA OS ships the lib (we list it in requirements) but not the
-# binary, which is what causes service detection to silently return nothing.
-_NMAP_BINARY_AVAILABLE = shutil.which("nmap") is not None
-_NMAP_AVAILABLE = _NMAP_LIB_AVAILABLE and _NMAP_BINARY_AVAILABLE
-
-if _NMAP_AVAILABLE:
-    _LOGGER.info("Scanner mode: nmap (binary + python-nmap detected)")
-elif _NMAP_LIB_AVAILABLE and not _NMAP_BINARY_AVAILABLE:
-    _LOGGER.info(
-        "Scanner mode: TCP fallback (python-nmap present but nmap binary "
-        "missing — typical on HA OS)"
-    )
-else:
-    _LOGGER.warning("python-nmap not available — scanner will run in mock mode")
-
-try:
     from zeroconf import ServiceStateChange
     from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo, AsyncZeroconf
 
@@ -119,16 +100,6 @@ def _resolve_hostname(ip: str) -> str | None:
         return socket.gethostbyaddr(ip)[0]
     except Exception:
         return None
-
-
-def _extract_os(nm: object, host: str) -> str | None:
-    try:
-        osmatch = nm[host].get("osmatch", [])  # type: ignore[index]
-        if osmatch:
-            return str(osmatch[0]["name"])
-    except Exception:
-        pass
-    return None
 
 
 def _arp_table_hosts(network: str) -> dict[str, dict[str, Any]]:
@@ -255,58 +226,12 @@ async def _ping_sweep(
     return alive
 
 
-def _nmap_scan_single(host_dict: dict[str, Any]) -> dict[str, Any]:
-    """Phase 2 (nmap path): per-IP service detection. Blocking — call via to_thread."""
-    ip = host_dict["ip"]
-    if not _NMAP_AVAILABLE:
-        return host_dict
-
-    is_root = os.geteuid() == 0 if hasattr(os, "geteuid") else False
-    base = "-sS" if is_root else "-sT"
-    scan_args = f"{base} -sV --open -T4 -Pn --host-timeout 60s -p {_EXTRA_PORTS}"
-
-    nm = nmap.PortScanner()
-    try:
-        nm.scan(hosts=ip, arguments=scan_args)
-    except Exception as exc:
-        _LOGGER.warning("[Phase 2] nmap failed for %s (%s)", ip, exc)
-        return host_dict
-
-    if ip not in nm.all_hosts():
-        return host_dict
-
-    open_ports = []
-    for proto in nm[ip].all_protocols():
-        for port, info in nm[ip][proto].items():
-            if info["state"] == "open":
-                banner = (
-                    info.get("product", "") + " " + info.get("version", "")
-                ).strip()
-                open_ports.append(
-                    {"port": port, "protocol": proto, "banner": banner}
-                )
-
-    host_dict["open_ports"] = open_ports
-    if not host_dict.get("mac"):
-        host_dict["mac"] = nm[ip].get("addresses", {}).get("mac")
-    host_dict["os"] = _extract_os(nm, ip)
-    _LOGGER.info(
-        "[trace] nmap_scan_single ip=%s open_ports=%d",
-        ip,
-        len(open_ports),
-    )
-    return host_dict
-
-
 async def _phase2_port_scan(
     alive: dict[str, dict[str, Any]],
     *,
     on_host_done: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
 ) -> list[dict[str, Any]]:
-    """Phase 2: per-IP port scan with bounded concurrency (10 hosts at a time).
-
-    Dispatches to nmap when the binary is available, falls back to a pure-Python
-    TCP connect scan otherwise. Both paths produce the same host_dict shape.
+    """Phase 2: per-IP TCP connect scan with bounded concurrency.
 
     `on_host_done` (if provided) is awaited per host as soon as that host's
     scan completes — the caller uses this to stream `device_enriched` events.
@@ -316,18 +241,9 @@ async def _phase2_port_scan(
 
     semaphore = asyncio.Semaphore(10)
 
-    async def _nmap_with_sem(host_dict: dict[str, Any]) -> dict[str, Any]:
-        async with semaphore:
-            return await asyncio.to_thread(_nmap_scan_single, host_dict)
-
-    async def _tcp_with_sem(host_dict: dict[str, Any]) -> dict[str, Any]:
-        async with semaphore:
-            return await tcp_connect_scan(host_dict, _PORT_LIST)
-
-    runner = _nmap_with_sem if _NMAP_AVAILABLE else _tcp_with_sem
-
     async def _scan_and_notify(host_dict: dict[str, Any]) -> dict[str, Any]:
-        result = await runner(host_dict)
+        async with semaphore:
+            result = await tcp_connect_scan(host_dict, _PORT_LIST)
         if on_host_done is not None:
             try:
                 await on_host_done(result)
@@ -348,19 +264,13 @@ async def _phase2_port_scan(
     return results
 
 
-async def _nmap_scan(
+async def _scan_target(
     target: str,
     *,
     on_phase1_host: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
     on_phase2_host: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
 ) -> list[dict[str, Any]]:
-    """Two-phase scan for a CIDR range (ping → port scan).
-
-    Falls back to a pure-Python TCP connect scan when the nmap binary is
-    missing. Returns mock data only when python-nmap itself is missing.
-    """
-    if not _NMAP_LIB_AVAILABLE:
-        return _mock_scan(target)
+    """Two-phase scan for a CIDR range (ping → TCP port scan)."""
     alive = await _ping_sweep(target, on_host=on_phase1_host)
     return await _phase2_port_scan(alive, on_host_done=on_phase2_host)
 
@@ -448,22 +358,6 @@ async def _mdns_discover(
     return list(discovered.values())
 
 
-def _mock_scan(target: str) -> list[dict[str, Any]]:
-    """Fake results for dev/test without nmap."""
-    return [
-        {
-            "ip": "192.168.1.99",
-            "hostname": "unknown-device.lan",
-            "mac": "AA:BB:CC:DD:EE:FF",
-            "os": None,
-            "open_ports": [
-                {"port": 80, "protocol": "tcp", "banner": "nginx"},
-                {"port": 22, "protocol": "tcp", "banner": "OpenSSH 9.0"},
-            ],
-        }
-    ]
-
-
 def _enrich(host: dict[str, Any], discovery_source: str) -> dict[str, Any]:
     """Add fingerprint + suggested_type + discovery_source to a host dict."""
     services = fingerprint_ports(host.get("open_ports", []))
@@ -528,7 +422,7 @@ async def run_scan(
                     "ip": ip,
                     "mac": host.get("mac"),
                     "hostname": host.get("hostname"),
-                    "discovery_source": "nmap",
+                    "discovery_source": "tcp",
                 },
             },
         )
@@ -541,13 +435,7 @@ async def run_scan(
         # already gated, but a host could enter via the ARP-only path).
         if ip in exclude_ips:
             return
-        enriched = _enrich(host, discovery_source="nmap")
-        _LOGGER.info(
-            "[trace] emit_phase2 ip=%s open_ports=%d services=%d",
-            ip,
-            len(enriched.get("open_ports", [])),
-            len(enriched.get("services", [])),
-        )
+        enriched = _enrich(host, discovery_source="tcp")
         await _safe_emit(
             on_event,
             {"event": "device_enriched", "device": enriched},
@@ -562,7 +450,7 @@ async def run_scan(
         for cidr in ranges:
             if _is_cancelled(run_id):
                 break
-            hosts = await _nmap_scan(
+            hosts = await _scan_target(
                 cidr,
                 on_phase1_host=_emit_phase1,
                 on_phase2_host=_emit_phase2,
@@ -576,7 +464,7 @@ async def run_scan(
                 # seen_ips was populated by _emit_phase1 above; for hosts that
                 # only came through the ARP fallback (no ping), add now.
                 seen_ips.add(ip)
-                devices.append(_enrich(host, discovery_source="nmap"))
+                devices.append(_enrich(host, discovery_source="tcp"))
 
         if not _is_cancelled(run_id):
             mdns_hosts = await mdns_task

--- a/custom_components/homelable/tcp_scanner.py
+++ b/custom_components/homelable/tcp_scanner.py
@@ -177,9 +177,4 @@ async def tcp_connect_scan(
 
     results = await asyncio.gather(*[_bound(p) for p in ports])
     host["open_ports"] = [r for r in results if r is not None]
-    _LOGGER.info(
-        "[trace] tcp_connect_scan ip=%s open_ports=%d",
-        ip,
-        len(host["open_ports"]),
-    )
     return host

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -48,7 +48,7 @@ async def test_trigger_scan_adds_new_device_to_pending(coord) -> None:  # noqa: 
             "open_ports": [{"port": 80, "protocol": "tcp", "banner": "nginx"}],
             "services": [],
             "suggested_type": "generic",
-            "discovery_source": "nmap",
+            "discovery_source": "tcp",
         }
     ]
     with patch(
@@ -136,7 +136,7 @@ async def test_streaming_events_create_then_enrich_pending(coord) -> None:  # no
                     "open_ports": [{"port": 22, "protocol": "tcp", "banner": "OpenSSH"}],
                     "services": [{"port": 22, "name": "ssh"}],
                     "suggested_type": "generic",
-                    "discovery_source": "nmap",
+                    "discovery_source": "tcp",
                 },
             }
         )
@@ -149,7 +149,7 @@ async def test_streaming_events_create_then_enrich_pending(coord) -> None:  # no
                 "open_ports": [{"port": 22, "protocol": "tcp", "banner": "OpenSSH"}],
                 "services": [{"port": 22, "name": "ssh"}],
                 "suggested_type": "generic",
-                "discovery_source": "nmap",
+                "discovery_source": "tcp",
             }
         ]
 
@@ -308,7 +308,7 @@ async def test_trigger_scan_updates_existing_pending_in_place(coord) -> None:  #
             "open_ports": [],
             "services": [],
             "suggested_type": "generic",
-            "discovery_source": "nmap",
+            "discovery_source": "tcp",
         }
     ]
     with patch(

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -17,7 +17,7 @@ async def test_run_scan_invalid_cidr_raises() -> None:
 async def test_run_scan_returns_enriched_devices() -> None:
     """Scan output carries services + suggested_type + discovery_source."""
 
-    async def _fake_nmap(target: str, **_kwargs) -> list[dict]:
+    async def _fake_scan(target: str, **_kwargs) -> list[dict]:
         return [
             {
                 "ip": "10.0.0.5",
@@ -28,11 +28,11 @@ async def test_run_scan_returns_enriched_devices() -> None:
             }
         ]
 
-    async def _no_mdns(timeout: float = 4.0) -> list[dict]:
+    async def _no_mdns(*_args, **_kwargs) -> list[dict]:
         return []
 
     with (
-        patch.object(scanner, "_nmap_scan", _fake_nmap),
+        patch.object(scanner, "_scan_target", _fake_scan),
         patch.object(scanner, "_mdns_discover", _no_mdns),
     ):
         devices = await scanner.run_scan(["10.0.0.0/24"])
@@ -40,7 +40,7 @@ async def test_run_scan_returns_enriched_devices() -> None:
     assert len(devices) == 1
     dev = devices[0]
     assert dev["ip"] == "10.0.0.5"
-    assert dev["discovery_source"] == "nmap"
+    assert dev["discovery_source"] == "tcp"
     assert "services" in dev
     assert "suggested_type" in dev
 
@@ -49,17 +49,17 @@ async def test_run_scan_returns_enriched_devices() -> None:
 async def test_run_scan_excludes_ips() -> None:
     """IPs in exclude_ips are skipped."""
 
-    async def _fake_nmap(target: str, **_kwargs) -> list[dict]:
+    async def _fake_scan(target: str, **_kwargs) -> list[dict]:
         return [
             {"ip": "10.0.0.5", "hostname": None, "mac": None, "os": None, "open_ports": []},
             {"ip": "10.0.0.6", "hostname": None, "mac": None, "os": None, "open_ports": []},
         ]
 
-    async def _no_mdns(timeout: float = 4.0) -> list[dict]:
+    async def _no_mdns(*_args, **_kwargs) -> list[dict]:
         return []
 
     with (
-        patch.object(scanner, "_nmap_scan", _fake_nmap),
+        patch.object(scanner, "_scan_target", _fake_scan),
         patch.object(scanner, "_mdns_discover", _no_mdns),
     ):
         devices = await scanner.run_scan(
@@ -71,20 +71,20 @@ async def test_run_scan_excludes_ips() -> None:
 
 @pytest.mark.asyncio
 async def test_run_scan_dedups_across_sources() -> None:
-    """Same IP from nmap + mdns surfaces once (nmap wins)."""
+    """Same IP from TCP scan + mdns surfaces once (TCP wins)."""
 
-    async def _fake_nmap(target: str, **_kwargs) -> list[dict]:
+    async def _fake_scan(target: str, **_kwargs) -> list[dict]:
         return [
             {
                 "ip": "10.0.0.7",
-                "hostname": "from-nmap",
+                "hostname": "from-tcp",
                 "mac": "AA:BB:CC:00:00:01",
                 "os": None,
                 "open_ports": [],
             }
         ]
 
-    async def _fake_mdns(timeout: float = 4.0) -> list[dict]:
+    async def _fake_mdns(*_args, **_kwargs) -> list[dict]:
         return [
             {
                 "ip": "10.0.0.7",
@@ -96,31 +96,31 @@ async def test_run_scan_dedups_across_sources() -> None:
         ]
 
     with (
-        patch.object(scanner, "_nmap_scan", _fake_nmap),
+        patch.object(scanner, "_scan_target", _fake_scan),
         patch.object(scanner, "_mdns_discover", _fake_mdns),
     ):
         devices = await scanner.run_scan(["10.0.0.0/24"])
 
     assert len(devices) == 1
-    assert devices[0]["discovery_source"] == "nmap"
-    assert devices[0]["hostname"] == "from-nmap"
+    assert devices[0]["discovery_source"] == "tcp"
+    assert devices[0]["hostname"] == "from-tcp"
 
 
 @pytest.mark.asyncio
 async def test_run_scan_cancel_short_circuits() -> None:
     """Cancelling a run_id prevents further hosts from being processed."""
 
-    async def _fake_nmap(target: str, **_kwargs) -> list[dict]:
+    async def _fake_scan(target: str, **_kwargs) -> list[dict]:
         scanner.request_cancel("test-run")
         return [
             {"ip": "10.0.0.5", "hostname": None, "mac": None, "os": None, "open_ports": []}
         ]
 
-    async def _no_mdns(timeout: float = 4.0) -> list[dict]:
+    async def _no_mdns(*_args, **_kwargs) -> list[dict]:
         return []
 
     with (
-        patch.object(scanner, "_nmap_scan", _fake_nmap),
+        patch.object(scanner, "_scan_target", _fake_scan),
         patch.object(scanner, "_mdns_discover", _no_mdns),
     ):
         devices = await scanner.run_scan(["10.0.0.0/24"], run_id="test-run")
@@ -129,8 +129,8 @@ async def test_run_scan_cancel_short_circuits() -> None:
 
 
 @pytest.mark.asyncio
-async def test_phase2_falls_back_to_tcp_scanner_when_nmap_binary_missing() -> None:
-    """Without the nmap binary, port scan dispatches to tcp_connect_scan."""
+async def test_phase2_dispatches_to_tcp_connect_scan() -> None:
+    """_phase2_port_scan delegates per-host work to tcp_connect_scan."""
     alive = {
         "10.0.0.5": {"ip": "10.0.0.5", "hostname": None, "mac": None, "os": None, "open_ports": []},
     }
@@ -139,10 +139,7 @@ async def test_phase2_falls_back_to_tcp_scanner_when_nmap_binary_missing() -> No
         host["open_ports"] = [{"port": 80, "protocol": "tcp", "banner": "nginx"}]
         return host
 
-    with (
-        patch.object(scanner, "_NMAP_AVAILABLE", False),
-        patch.object(scanner, "tcp_connect_scan", _fake_tcp),
-    ):
+    with patch.object(scanner, "tcp_connect_scan", _fake_tcp):
         results = await scanner._phase2_port_scan(alive)
 
     assert len(results) == 1
@@ -150,31 +147,26 @@ async def test_phase2_falls_back_to_tcp_scanner_when_nmap_binary_missing() -> No
 
 
 @pytest.mark.asyncio
-async def test_phase2_uses_nmap_when_available() -> None:
-    """With nmap available, port scan dispatches to _nmap_scan_single."""
+async def test_phase2_invokes_on_host_done_callback() -> None:
+    """Per-host callback fires once tcp_connect_scan returns."""
     alive = {
         "10.0.0.5": {"ip": "10.0.0.5", "hostname": None, "mac": None, "os": None, "open_ports": []},
     }
-    tcp_called = False
+    seen: list[dict] = []
 
     async def _fake_tcp(host: dict, ports: tuple[int, ...]) -> dict:
-        nonlocal tcp_called
-        tcp_called = True
+        host["open_ports"] = [{"port": 22, "protocol": "tcp", "banner": ""}]
         return host
 
-    def _fake_nmap_single(host: dict) -> dict:
-        host["open_ports"] = [{"port": 22, "protocol": "tcp", "banner": "OpenSSH"}]
-        return host
+    async def _on_done(host: dict) -> None:
+        seen.append(host)
 
-    with (
-        patch.object(scanner, "_NMAP_AVAILABLE", True),
-        patch.object(scanner, "_nmap_scan_single", _fake_nmap_single),
-        patch.object(scanner, "tcp_connect_scan", _fake_tcp),
-    ):
-        results = await scanner._phase2_port_scan(alive)
+    with patch.object(scanner, "tcp_connect_scan", _fake_tcp):
+        await scanner._phase2_port_scan(alive, on_host_done=_on_done)
 
-    assert tcp_called is False
-    assert results[0]["open_ports"] == [{"port": 22, "protocol": "tcp", "banner": "OpenSSH"}]
+    assert len(seen) == 1
+    assert seen[0]["ip"] == "10.0.0.5"
+    assert seen[0]["open_ports"][0]["port"] == 22
 
 
 def test_request_cancel_records_run_id() -> None:


### PR DESCRIPTION
Diagnostic traces showed nmap silently producing empty results on HA OS (binary present, scan succeeded, no hosts in the parsed result). Drop the nmap path entirely.

Phase 2 always runs the pure-Python TCP connect scan now. No subprocess, no root, no XML parsing. Drops `python-nmap` from manifest requirements. Verified locally — services populate as expected.

~150 lines deleted, 93/93 tests green.