### PR TITLE
feat(scanner): TCP fallback for cross-subnet scans + read-only ranges in modal

### DIFF
--- a/custom_components/homelable/scanner.py
+++ b/custom_components/homelable/scanner.py
@@ -270,9 +270,43 @@ async def _scan_target(
     on_phase1_host: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
     on_phase2_host: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
 ) -> list[dict[str, Any]]:
-    """Two-phase scan for a CIDR range (ping → TCP port scan)."""
+    """Two-phase scan for a CIDR range (ping → TCP port scan).
+
+    If ping + ARP yield zero hosts (foreign subnet, unprivileged container with
+    no CAP_NET_RAW, ICMP-blocked LAN), fall back to a full TCP sweep across
+    every IP in the CIDR. Slower but catches cases where ping is the blocker.
+    """
     alive = await _ping_sweep(target, on_host=on_phase1_host)
-    return await _phase2_port_scan(alive, on_host_done=on_phase2_host)
+    if alive:
+        return await _phase2_port_scan(alive, on_host_done=on_phase2_host)
+
+    _LOGGER.info(
+        "[Phase 1] no hosts via ping/ARP for %s — full TCP sweep fallback", target
+    )
+    net = ipaddress.ip_network(target, strict=False)
+    full_alive: dict[str, dict[str, Any]] = {
+        str(ip): {
+            "ip": str(ip),
+            "mac": None,
+            "hostname": None,
+            "os": None,
+            "open_ports": [],
+        }
+        for ip in net.hosts()
+    }
+
+    async def _filtered_phase2(host: dict[str, Any]) -> None:
+        if not host.get("open_ports"):
+            return
+        if host.get("hostname") is None:
+            host["hostname"] = await asyncio.to_thread(_resolve_hostname, host["ip"])
+        if on_phase1_host is not None:
+            await on_phase1_host(host)
+        if on_phase2_host is not None:
+            await on_phase2_host(host)
+
+    results = await _phase2_port_scan(full_alive, on_host_done=_filtered_phase2)
+    return [h for h in results if h.get("open_ports")]
 
 
 async def _mdns_discover(

--- a/frontend-src/src/api/ha.ts
+++ b/frontend-src/src/api/ha.ts
@@ -106,9 +106,6 @@ export const scanApi = {
     const result = await wsCall<{ ranges: string[] }>('homelable/scan/get_config')
     return toAxiosLike(result)
   },
-  // Save not yet wired — ranges still live in the HA options flow. Accept the
-  // call so the modal can proceed; the trigger uses the entry-configured ranges.
-  saveConfig: async (data: { ranges: string[] }) => toAxiosLike(data),
 }
 
 // ─── Settings (stubbed: HA owns config via options flow) ────────────────────

--- a/frontend-src/src/components/modals/ScanConfigModal.tsx
+++ b/frontend-src/src/components/modals/ScanConfigModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { Plus, Trash2, Settings } from 'lucide-react'
+import { Settings } from 'lucide-react'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -14,22 +14,23 @@ interface ScanConfigModalProps {
 }
 
 export function ScanConfigModal({ open, onClose, onScanNow }: ScanConfigModalProps) {
-  const [ranges, setRanges] = useState<string[]>([''])
+  const [ranges, setRanges] = useState<string[]>([])
   const [saving, setSaving] = useState(false)
 
   useEffect(() => {
     if (!open) return
     scanApi.getConfig()
-      .then((res) => setRanges(res.data.ranges.length > 0 ? res.data.ranges : ['']))
-      .catch(() => {/* use defaults */})
+      .then((res) => setRanges(res.data.ranges))
+      .catch(() => setRanges([]))
   }, [open])
 
   const handleScanNow = async () => {
-    const cleaned = ranges.map((r) => r.trim()).filter(Boolean)
-    if (cleaned.length === 0) { toast.error('Add at least one IP range'); return }
+    if (ranges.length === 0) {
+      toast.error('No IP ranges configured — set them in the integration options')
+      return
+    }
     setSaving(true)
     try {
-      await scanApi.saveConfig({ ranges: cleaned })
       const res = await scanApi.trigger()
       if (res.data?.status === 'already_running') {
         toast.message('A scan is already running')
@@ -53,45 +54,31 @@ export function ScanConfigModal({ open, onClose, onScanNow }: ScanConfigModalPro
         </DialogHeader>
 
         <div className="space-y-4 py-2">
-          {/* IP Ranges */}
           <div className="space-y-2">
             <Label className="text-sm text-muted-foreground">IP Ranges (CIDR)</Label>
-            {ranges.map((r, i) => (
-              <div key={i} className="flex gap-2">
+            {ranges.length === 0 ? (
+              <p className="text-sm text-muted-foreground italic">
+                No ranges configured.
+              </p>
+            ) : (
+              ranges.map((r, i) => (
                 <Input
+                  key={i}
                   value={r}
-                  onChange={(e) => {
-                    const next = [...ranges]
-                    next[i] = e.target.value
-                    setRanges(next)
-                  }}
-                  placeholder="192.168.1.0/24"
+                  readOnly
+                  disabled
                   className="font-mono text-sm bg-[#0d1117] border-border"
                 />
-                <Button
-                  size="icon"
-                  variant="ghost"
-                  className="shrink-0 text-muted-foreground hover:text-[#f85149]"
-                  onClick={() => setRanges(ranges.filter((_, j) => j !== i))}
-                  disabled={ranges.length === 1}
-                >
-                  <Trash2 size={14} />
-                </Button>
-              </div>
-            ))}
-            <Button
-              size="sm"
-              variant="ghost"
-              className="gap-1.5 text-muted-foreground hover:text-foreground"
-              onClick={() => setRanges([...ranges, ''])}
-            >
-              <Plus size={13} /> Add range
-            </Button>
+              ))
+            )}
           </div>
 
-          <p className="text-xs text-muted-foreground flex items-center gap-1.5">
-            <Settings size={11} />
-            Status check interval can be configured in the sidebar Settings.
+          <p className="text-xs text-muted-foreground flex items-start gap-1.5">
+            <Settings size={11} className="mt-0.5 shrink-0" />
+            <span>
+              Ranges are managed in <strong>Settings → Devices &amp; services → Homelable → Configure</strong>.
+              Status check interval is configured there too.
+            </span>
           </p>
         </div>
 
@@ -99,7 +86,7 @@ export function ScanConfigModal({ open, onClose, onScanNow }: ScanConfigModalPro
           <Button variant="ghost" onClick={onClose}>Cancel</Button>
           <Button
             onClick={handleScanNow}
-            disabled={saving}
+            disabled={saving || ranges.length === 0}
             style={{ background: '#00d4ff', color: '#0d1117' }}
           >
             Scan Now

--- a/frontend-src/src/components/modals/__tests__/ScanConfigModal.test.tsx
+++ b/frontend-src/src/components/modals/__tests__/ScanConfigModal.test.tsx
@@ -5,11 +5,10 @@ import { ScanConfigModal } from '../ScanConfigModal'
 vi.mock('@/api/client', () => ({
   scanApi: {
     getConfig: vi.fn(),
-    saveConfig: vi.fn(),
     trigger: vi.fn(),
   },
 }))
-vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() } }))
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn(), info: vi.fn(), message: vi.fn() } }))
 
 import { scanApi } from '@/api/client'
 import { toast } from 'sonner'
@@ -19,8 +18,6 @@ const defaultConfig = { data: { ranges: ['192.168.1.0/24'] } }
 describe('ScanConfigModal', () => {
   beforeEach(() => {
     vi.mocked(scanApi.getConfig).mockResolvedValue(defaultConfig as never)
-    vi.mocked(scanApi.saveConfig).mockReset()
-    vi.mocked(scanApi.saveConfig).mockResolvedValue({} as never)
     vi.mocked(scanApi.trigger).mockReset()
     vi.mocked(scanApi.trigger).mockResolvedValue({} as never)
     vi.mocked(toast.success).mockReset()
@@ -32,57 +29,38 @@ describe('ScanConfigModal', () => {
     expect(container.querySelector('[role="dialog"]')).toBeNull()
   })
 
-  it('loads config from API on open', async () => {
+  it('loads config from API on open and shows ranges read-only', async () => {
     render(<ScanConfigModal open onClose={vi.fn()} onScanNow={vi.fn()} />)
     await waitFor(() => {
       expect(scanApi.getConfig).toHaveBeenCalledOnce()
     })
-    const input = await screen.findByDisplayValue('192.168.1.0/24')
-    expect(input).toBeDefined()
+    const input = await screen.findByDisplayValue('192.168.1.0/24') as HTMLInputElement
+    expect(input.disabled).toBe(true)
+    expect(input.readOnly).toBe(true)
   })
 
-  it('adds a new empty range on "Add range" click', async () => {
-    render(<ScanConfigModal open onClose={vi.fn()} onScanNow={vi.fn()} />)
-    await screen.findByDisplayValue('192.168.1.0/24')
-    fireEvent.click(screen.getByText('Add range'))
-    const inputs = screen.getAllByPlaceholderText('192.168.1.0/24')
-    expect(inputs).toHaveLength(2)
-  })
-
-  it('delete button disabled when only one range', async () => {
-    render(<ScanConfigModal open onClose={vi.fn()} onScanNow={vi.fn()} />)
-    await screen.findByDisplayValue('192.168.1.0/24')
-    const trashButtons = document.querySelectorAll('button[disabled]')
-    expect(trashButtons.length).toBeGreaterThan(0)
-  })
-
-  it('can remove a range when more than one exist', async () => {
-    vi.mocked(scanApi.getConfig).mockResolvedValue({ data: { ranges: ['192.168.1.0/24', '10.0.0.0/8'] } } as never)
-    render(<ScanConfigModal open onClose={vi.fn()} onScanNow={vi.fn()} />)
-    await screen.findByDisplayValue('192.168.1.0/24')
-    const trashButtons = screen.getAllByRole('button').filter((b) => !b.hasAttribute('disabled') && b.querySelector('svg'))
-    expect(trashButtons.length).toBeGreaterThanOrEqual(2)
-  })
-
-  it('shows error toast and does not save when all ranges are empty', async () => {
-    vi.mocked(scanApi.getConfig).mockResolvedValue({ data: { ranges: [''] } } as never)
+  it('shows hint pointing to integration options', async () => {
     render(<ScanConfigModal open onClose={vi.fn()} onScanNow={vi.fn()} />)
     await waitFor(() => expect(scanApi.getConfig).toHaveBeenCalled())
-    fireEvent.click(screen.getByRole('button', { name: 'Scan Now' }))
-    await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith('Add at least one IP range')
-    })
-    expect(scanApi.saveConfig).not.toHaveBeenCalled()
+    expect(screen.getByText(/Devices & services/)).toBeDefined()
   })
 
-  it('saves config, triggers scan, calls onScanNow and closes on "Scan Now" click', async () => {
+  it('disables Scan Now and shows empty state when no ranges configured', async () => {
+    vi.mocked(scanApi.getConfig).mockResolvedValue({ data: { ranges: [] } } as never)
+    render(<ScanConfigModal open onClose={vi.fn()} onScanNow={vi.fn()} />)
+    await waitFor(() => expect(scanApi.getConfig).toHaveBeenCalled())
+    expect(screen.getByText('No ranges configured.')).toBeDefined()
+    const btn = screen.getByRole('button', { name: 'Scan Now' }) as HTMLButtonElement
+    expect(btn.disabled).toBe(true)
+  })
+
+  it('triggers scan, calls onScanNow and closes on "Scan Now" click', async () => {
     const onScanNow = vi.fn()
     const onClose = vi.fn()
     render(<ScanConfigModal open onClose={onClose} onScanNow={onScanNow} />)
     await screen.findByDisplayValue('192.168.1.0/24')
     fireEvent.click(screen.getByRole('button', { name: 'Scan Now' }))
     await waitFor(() => {
-      expect(scanApi.saveConfig).toHaveBeenCalledWith({ ranges: ['192.168.1.0/24'] })
       expect(scanApi.trigger).toHaveBeenCalledOnce()
       expect(onScanNow).toHaveBeenCalledOnce()
       expect(onClose).toHaveBeenCalledOnce()
@@ -95,17 +73,5 @@ describe('ScanConfigModal', () => {
     await waitFor(() => expect(scanApi.getConfig).toHaveBeenCalled())
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
     expect(onClose).toHaveBeenCalledOnce()
-  })
-
-  it('strips whitespace from ranges before scanning', async () => {
-    render(<ScanConfigModal open onClose={vi.fn()} onScanNow={vi.fn()} />)
-    const input = await screen.findByDisplayValue('192.168.1.0/24')
-    fireEvent.change(input, { target: { value: '  10.0.0.0/8  ' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Scan Now' }))
-    await waitFor(() => {
-      expect(scanApi.saveConfig).toHaveBeenCalledWith(
-        expect.objectContaining({ ranges: ['10.0.0.0/8'] })
-      )
-    })
   })
 })


### PR DESCRIPTION
## Summary

Two related fixes:

### Scanner: full-CIDR TCP fallback
Cross-subnet scans (e.g. `192.168.3.0/24` from a HA host on `192.168.1.0/24`) returned zero devices because:
- ping fails inside the unprivileged HA container (no `CAP_NET_RAW`)
- the kernel ARP cache holds no entries for foreign L2 segments

Phase 2 was skipped entirely despite hosts being TCP-reachable via the gateway. `_scan_target` now falls back to a full TCP sweep across every IP in the CIDR when ping + ARP return 0 hosts, keeping only IPs with ≥1 open port. Hostname resolved lazily for survivors. Same phase1/phase2 events emitted so the panel UI is unchanged.

Trade-off: fallback path is slower (full /24 ~60–90s with current concurrency) but only triggers when the normal path already failed.

### Panel: read-only ranges in scan modal (closes #8)
The HA build's `scanApi.saveConfig` was a no-op stub — ranges are owned by the integration options flow — so edits in the modal silently dropped. Modal now displays ranges read-only with a hint pointing to **Settings → Devices & services → Homelable → Configure**. Add/remove buttons and the no-op adapter dropped. Empty-config state disables Scan Now.

## Test plan
- [x] `ruff check custom_components/`
- [x] `pytest` — 93 passed
- [x] `npm test` — 764 passed
- [ ] Manual: scan a foreign-subnet CIDR from HA OS, confirm devices surface
- [ ] Manual: scan local subnet, confirm normal ping path still used (no regression in speed)
- [ ] Manual: open scan modal, confirm ranges read-only and hint visible