### PR TITLE
fix: empty scan nodes (#164) + blocking open() in scan loop

### DIFF
--- a/custom_components/homelable/coordinator.py
+++ b/custom_components/homelable/coordinator.py
@@ -217,8 +217,11 @@ class HomelableCoordinator(DataUpdateCoordinator):
 
         Idempotent: skips if an edge with the same source+target already exists.
         """
+        # Nodes may be flat (top-level fields) or nested ({data: {...}}) depending
+        # on whether they were just approved or round-tripped through the
+        # frontend; read both shapes.
         data = child_node.get("data") or {}
-        parent_ieee = data.get("parent_id")
+        parent_ieee = child_node.get("parent_id") or data.get("parent_id")
         if not parent_ieee:
             return None
         canvas = await self.get_canvas()
@@ -226,7 +229,8 @@ class HomelableCoordinator(DataUpdateCoordinator):
             (
                 n
                 for n in canvas.get("nodes", [])
-                if (n.get("data") or {}).get("ieee_address") == parent_ieee
+                if (n.get("ieee_address") or (n.get("data") or {}).get("ieee_address"))
+                == parent_ieee
             ),
             None,
         )
@@ -279,26 +283,33 @@ class HomelableCoordinator(DataUpdateCoordinator):
         # vendor, lqi, parent_id) under data_extras; merge them so the node on
         # the canvas has everything the zigbee node component renders.
         data_extras = device.get("data_extras") or {}
+        # Canvas nodes are stored FLAT (top-level ip/services/pos_x/...), to
+        # match what the frontend serializes on Save and reads back on load
+        # (deserializeApiNode). Building a nested {position, data:{...}} node
+        # here would deserialize to an empty node (undefined ip/services/pos)
+        # on the next reload, until the user happens to press Save and the
+        # frontend rewrites every node flat. Keep it flat from the start.
+        position = overrides.get("position") or {"x": 0, "y": 0}
         node = {
             "id": overrides.get("id")
-            or device.get("data_extras", {}).get("ieee_address")
+            or data_extras.get("ieee_address")
             or f"node-{uuid.uuid4().hex[:8]}",
             "type": node_type,
-            "position": overrides.get("position") or {"x": 0, "y": 0},
-            "data": {
-                "label": overrides.get("label")
-                or device.get("hostname")
-                or device.get("ip")
-                or data_extras.get("friendly_name"),
-                "ip": device.get("ip"),
-                "mac": device.get("mac"),
-                "hostname": device.get("hostname"),
-                "os": device.get("os"),
-                "services": device.get("services", []),
-                "check_method": overrides.get("check_method", default_check),
-                **data_extras,
-                **overrides.get("data", {}),
-            },
+            "label": overrides.get("label")
+            or device.get("hostname")
+            or device.get("ip")
+            or data_extras.get("friendly_name"),
+            "ip": device.get("ip"),
+            "mac": device.get("mac"),
+            "hostname": device.get("hostname"),
+            "os": device.get("os"),
+            "services": device.get("services", []),
+            "status": overrides.get("status", "unknown"),
+            "check_method": overrides.get("check_method", default_check),
+            "pos_x": position.get("x", 0),
+            "pos_y": position.get("y", 0),
+            **data_extras,
+            **overrides.get("data", {}),
         }
 
         canvas = await self.get_canvas()
@@ -630,10 +641,12 @@ class HomelableCoordinator(DataUpdateCoordinator):
         canvas = await self.get_canvas()
 
         # IEEE addresses already represented anywhere — avoid duplicates.
+        # Canvas nodes may be flat (top-level ieee_address) or nested under
+        # `data`; read both so an approved zigbee node isn't re-imported.
         on_canvas = {
-            n.get("data", {}).get("ieee_address")
+            ieee
             for n in canvas.get("nodes", [])
-            if n.get("data", {}).get("ieee_address")
+            if (ieee := n.get("ieee_address") or n.get("data", {}).get("ieee_address"))
         }
         already_pending = {
             d.get("data_extras", {}).get("ieee_address")

--- a/custom_components/homelable/fingerprint.py
+++ b/custom_components/homelable/fingerprint.py
@@ -26,6 +26,17 @@ def _load() -> list[dict[str, Any]]:
     return _SIGNATURES
 
 
+def preload() -> None:
+    """Warm the signature cache via a blocking file read.
+
+    Call this off the event loop (``asyncio.to_thread`` / executor) before the
+    first ``match_port`` so the cache is populated; otherwise ``_load`` runs its
+    blocking ``open()`` inside the loop and trips Home Assistant's blocking-call
+    detector.
+    """
+    _load()
+
+
 def match_port(port: int, protocol: str, banner: str | None = None) -> dict[str, Any] | None:
     """Return the first signature matching port+protocol, optionally banner."""
     for sig in _load():

--- a/custom_components/homelable/scanner.py
+++ b/custom_components/homelable/scanner.py
@@ -22,6 +22,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 from .fingerprint import fingerprint_ports, suggest_node_type
+from .fingerprint import preload as preload_fingerprints
 from .tcp_scanner import tcp_connect_scan
 
 # Coroutine the caller can pass to receive incremental scan events. Schema:
@@ -439,6 +440,11 @@ async def run_scan(
             ipaddress.ip_network(r, strict=False)
         except ValueError as err:
             raise ValueError(f"Invalid CIDR range: {r!r}") from err
+
+    # Warm the fingerprint signature cache off the event loop. _enrich() runs
+    # synchronously inside the async scan loop, so the first (blocking) file
+    # read otherwise trips HA's blocking-call detector.
+    await asyncio.to_thread(preload_fingerprints)
 
     devices: list[dict[str, Any]] = []
     seen_ips: set[str] = set()

--- a/frontend-src/src/utils/__tests__/canvasSerializer.test.ts
+++ b/frontend-src/src/utils/__tests__/canvasSerializer.test.ts
@@ -325,6 +325,51 @@ describe('deserializeApiNode — regular node', () => {
   })
 })
 
+// ── deserializeApiNode — nested fallback ──────────────────────────────────────
+
+describe('deserializeApiNode — nested {position, data} fallback', () => {
+  const emptyMap = new Map<string, boolean>()
+
+  // Defensive: a node appended server-side (e.g. an approved scan device on an
+  // older build) can arrive nested instead of flat. Without flattening, ip /
+  // services / position read as undefined and the node renders empty (#164).
+  const nested = {
+    id: 'scan-1',
+    type: 'server',
+    position: { x: 320, y: 140 },
+    data: {
+      label: 'NAS',
+      type: 'server',
+      ip: '192.168.1.20',
+      hostname: 'nas',
+      status: 'unknown',
+      services: [{ name: 'http', port: 80 }],
+    },
+  } as unknown as ApiNode
+
+  it('recovers ip, services and label from data', () => {
+    const result = deserializeApiNode(nested, emptyMap)
+    expect(result.data.ip).toBe('192.168.1.20')
+    expect(result.data.hostname).toBe('nas')
+    expect(result.data.services).toEqual([{ name: 'http', port: 80 }])
+    expect(result.data.label).toBe('NAS')
+  })
+
+  it('recovers position from nested position object', () => {
+    const result = deserializeApiNode(nested, emptyMap)
+    expect(result.position).toEqual({ x: 320, y: 140 })
+  })
+
+  it('still reads flat nodes unchanged', () => {
+    const result = deserializeApiNode(
+      makeApiNode({ ip: '10.0.0.1', services: [{ name: 'ssh', port: 22 }] }),
+      emptyMap,
+    )
+    expect(result.data.ip).toBe('10.0.0.1')
+    expect(result.position).toEqual({ x: 100, y: 200 })
+  })
+})
+
 // ── deserializeApiNode — groupRect ────────────────────────────────────────────
 
 describe('deserializeApiNode — groupRect', () => {

--- a/frontend-src/src/utils/canvasSerializer.ts
+++ b/frontend-src/src/utils/canvasSerializer.ts
@@ -133,9 +133,27 @@ export function serializeEdge(e: Edge<EdgeData>): Record<string, unknown> {
 // ── Deserialization (API response → RF node/edge) ────────────────────────────
 
 export function deserializeApiNode(
-  n: ApiNode,
+  rawNode: ApiNode,
   proxmoxContainerMap: Map<string, boolean>,
 ): Node<NodeData> {
+  // Defensive: most nodes are stored flat (top-level ip/services/pos_x), but a
+  // node appended server-side (e.g. an approved scan device on older builds)
+  // may arrive nested as { position, data: {...} }. Flatten it so the rest of
+  // this function — and the canvas — sees one consistent shape.
+  const nested = rawNode as ApiNode & {
+    position?: { x?: number; y?: number }
+    data?: Record<string, unknown>
+  }
+  const n: ApiNode =
+    nested.data && typeof nested.data === 'object' && nested.pos_x === undefined
+      ? ({
+          ...nested.data,
+          id: nested.id,
+          type: nested.type ?? (nested.data.type as string),
+          pos_x: nested.position?.x ?? 0,
+          pos_y: nested.position?.y ?? 0,
+        } as ApiNode)
+      : rawNode
   const normalizedType = n.type === 'docker' ? 'docker_host' : n.type
   if (n.type === 'groupRect') {
     const w = (n.custom_colors?.width as number | undefined) ?? 360

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -243,13 +243,113 @@ async def test_approve_pending_creates_canvas_node(coord) -> None:  # noqa: ANN0
 
     assert node is not None
     assert node["type"] == "server"
-    assert node["data"]["ip"] == "10.0.0.5"
-    assert node["position"] == {"x": 100, "y": 50}
+    # Nodes are stored FLAT (top-level fields), matching what the frontend
+    # serializes on Save and reads back via deserializeApiNode. A nested
+    # {position, data:{...}} node would deserialize to empty (no ip/services)
+    # on the next reload. See approve_pending.
+    assert "data" not in node
+    assert node["ip"] == "10.0.0.5"
+    assert node["hostname"] == "myhost"
+    assert node["services"] == []
+    assert node["label"] == "myhost"
+    assert node["status"] == "unknown"
+    assert node["pos_x"] == 100
+    assert node["pos_y"] == 50
 
     canvas = await coord.get_canvas()
     assert len(canvas["nodes"]) == 1
+    # the persisted node carries ip/services flat, so a frontend reload sees them
+    stored = canvas["nodes"][0]
+    assert stored["ip"] == "10.0.0.5"
+    assert stored["services"] == []
+    assert stored["pos_x"] == 100
     # device removed from pending
     assert await coord.list_pending() == []
+
+
+@pytest.mark.asyncio
+async def test_approve_pending_node_has_services_flat(coord) -> None:  # noqa: ANN001
+    """Regression: approved scan devices must keep ip + services on the node.
+
+    Previously approve_pending emitted a nested {position, data:{...}} node;
+    the frontend deserializer reads flat top-level keys, so on the next reload
+    ip/services were undefined and the node rendered empty (issue homelable#164).
+    """
+    pending = await coord._get_pending()
+    pending["devices"].append(
+        {
+            "id": "pd-svc",
+            "ip": "192.168.1.20",
+            "mac": "aa:bb:cc:dd:ee:ff",
+            "hostname": "nas",
+            "os": "linux",
+            "services": [{"name": "http", "port": 80}],
+            "suggested_type": "nas",
+            "status": "pending",
+        }
+    )
+    await coord._save_pending()
+
+    node = await coord.approve_pending("pd-svc")
+
+    assert node["ip"] == "192.168.1.20"
+    assert node["mac"] == "aa:bb:cc:dd:ee:ff"
+    assert node["os"] == "linux"
+    assert node["services"] == [{"name": "http", "port": 80}]
+    assert node["check_method"] == "ping"
+
+
+@pytest.mark.asyncio
+async def test_approve_zigbee_child_links_to_flat_parent(coord) -> None:  # noqa: ANN001
+    """Approving a zigbee child should link to an already-approved (flat) parent.
+
+    Both parent and child are stored flat (ieee_address / parent_id top-level),
+    so _create_zigbee_parent_edge must match on the flat shape.
+    """
+    # Parent already approved → flat node on the canvas.
+    pending = await coord._get_pending()
+    pending["devices"].append(
+        {
+            "id": "pd-parent",
+            "ip": None,
+            "mac": None,
+            "hostname": "Router",
+            "os": None,
+            "services": [],
+            "suggested_type": "zigbee_router",
+            "source": "zigbee",
+            "status": "pending",
+            "data_extras": {"ieee_address": "0xR1", "parent_id": None},
+        }
+    )
+    await coord._save_pending()
+    parent_node = await coord.approve_pending("pd-parent")
+    assert parent_node["ieee_address"] == "0xR1"
+    assert "data" not in parent_node
+
+    # Child references the parent by ieee_address.
+    pending = await coord._get_pending()
+    pending["devices"].append(
+        {
+            "id": "pd-child",
+            "ip": None,
+            "mac": None,
+            "hostname": "Bulb",
+            "os": None,
+            "services": [],
+            "suggested_type": "zigbee_router",
+            "source": "zigbee",
+            "status": "pending",
+            "data_extras": {"ieee_address": "0xC1", "parent_id": "0xR1"},
+        }
+    )
+    await coord._save_pending()
+    child_node = await coord.approve_pending("pd-child")
+
+    edge = await coord._create_zigbee_parent_edge(child_node)
+    assert edge is not None
+    assert edge["source"] == parent_node["id"]
+    assert edge["target"] == child_node["id"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -1,7 +1,9 @@
 """Tests for the fingerprint module."""
+from custom_components.homelable import fingerprint
 from custom_components.homelable.fingerprint import (
     fingerprint_ports,
     match_port,
+    preload,
     suggest_node_type,
     suggest_type_from_mac,
 )
@@ -49,3 +51,27 @@ def test_suggest_node_type_iot_mac_wins_over_http() -> None:
 
 def test_suggest_node_type_no_signal_falls_back_to_generic() -> None:
     assert suggest_node_type([]) == "generic"
+
+
+def test_preload_populates_cache_so_match_port_does_no_io() -> None:
+    """preload() warms the cache; subsequent matches must not touch the file.
+
+    The scanner calls preload() in a thread before enrichment so the blocking
+    file read never runs on the event loop (HA blocking-call detector).
+    """
+    fingerprint._SIGNATURES = None
+    preload()
+    assert fingerprint._SIGNATURES is not None
+
+    # With the cache warm, a match must not re-open the file.
+    import builtins
+
+    def _boom(*_args, **_kwargs):  # noqa: ANN002, ANN003
+        raise AssertionError("match_port should not open files after preload()")
+
+    original_open = builtins.open
+    builtins.open = _boom
+    try:
+        assert match_port(22, "tcp") is not None
+    finally:
+        builtins.open = original_open

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -145,7 +145,9 @@ async def test_scan_approve_existing(
     )
     msg = await client.receive_json()
     assert msg["success"] is True
-    assert msg["result"]["node"]["data"]["ip"] == "10.0.0.6"
+    # Node is returned (and stored) flat — top-level ip, not nested under data.
+    assert msg["result"]["node"]["ip"] == "10.0.0.6"
+    assert msg["result"]["node"]["pos_x"] == 1
 
 
 async def test_scan_approve_unknown_returns_error(


### PR DESCRIPTION
## Summary

Two scan-related fixes.

### 1. Approved scan nodes lose ip/services on reload (homelable#164)

`approve_pending` built a **nested** `{position, data:{...}}` node and saved it to the canvas, but the canvas storage convention is **flat** (top-level `ip`/`services`/`pos_x`) — that's what the frontend serializes on Save and reads back via `deserializeApiNode`. An approved node showed fine in-session (frontend `addNode`) but deserialized to an empty node (undefined `ip`/`services`/`position`) on the next reload, unless the user happened to press Save and rewrite every node flat. That's why it wasn't always reproducible — saving normalized the canvas.

- `approve_pending` now emits a flat node matching the storage/`ApiNode` shape.
- `_create_zigbee_parent_edge` and `import_zigbee_devices` read `ieee_address` / `parent_id` flat-or-nested.
- `deserializeApiNode` flattens a nested `{position, data}` node defensively, to recover canvases saved by older builds.

### 2. Blocking `open()` inside the scan event loop

`_enrich()` runs synchronously inside the async scan loop, so the first fingerprint match did a blocking `open()` of `service_signatures.json` on the event loop, tripping HA's blocking-call detector. Added `fingerprint.preload()` and call it via `asyncio.to_thread` at the start of `run_scan`, before any enrichment — the per-host match then hits the warm cache and never opens a file on the loop.

## Tests

- `test_coordinator.py`: approved-node flat shape + regression for #164 + zigbee child→flat parent edge.
- `test_websocket.py`: approve asserts top-level `ip`/`pos_x`.
- `test_fingerprint.py`: `preload()` warms cache, `match_port` does no file I/O afterward.
- `canvasSerializer.test.ts`: nested→flat fallback.

110 backend tests + frontend serializer tests pass; ruff clean.