### PR TITLE
feat(zigbee): IEEE/Vendor/Model/LQI properties on approve + re-import

### DIFF
--- a/custom_components/homelable/coordinator.py
+++ b/custom_components/homelable/coordinator.py
@@ -279,10 +279,25 @@ class HomelableCoordinator(DataUpdateCoordinator):
             device.get("source") == "zigbee" or node_type.startswith("zigbee_")
         )
         default_check = "none" if is_zigbee else "ping"
+        # Zigbee devices report from Z2M as reachable, so they land online; the
+        # status checker never polls them (check_method "none").
+        default_status = "online" if is_zigbee else "unknown"
         # Zigbee devices carry their own canonical fields (ieee_address, model,
         # vendor, lqi, parent_id) under data_extras; merge them so the node on
         # the canvas has everything the zigbee node component renders.
         data_extras = device.get("data_extras") or {}
+        # Surface IEEE/Vendor/Model/LQI as right-panel property rows (hidden by
+        # default — users opt in to showing them on the canvas card).
+        zigbee_props = (
+            zigbee.build_zigbee_properties(
+                data_extras.get("ieee_address"),
+                data_extras.get("vendor"),
+                data_extras.get("model"),
+                data_extras.get("lqi"),
+            )
+            if is_zigbee
+            else []
+        )
         # Canvas nodes are stored FLAT (top-level ip/services/pos_x/...), to
         # match what the frontend serializes on Save and reads back on load
         # (deserializeApiNode). Building a nested {position, data:{...}} node
@@ -304,8 +319,9 @@ class HomelableCoordinator(DataUpdateCoordinator):
             "hostname": device.get("hostname"),
             "os": device.get("os"),
             "services": device.get("services", []),
-            "status": overrides.get("status", "unknown"),
+            "status": overrides.get("status", default_status),
             "check_method": overrides.get("check_method", default_check),
+            "properties": zigbee_props,
             "pos_x": position.get("x", 0),
             "pos_y": position.get("y", 0),
             **data_extras,
@@ -632,10 +648,11 @@ class HomelableCoordinator(DataUpdateCoordinator):
         """Push selected Zigbee devices into the pending store.
 
         Each entry in `devices` is a parsed networkmap node dict from
-        ``zigbee.parse_networkmap``. Already-pending or already-on-canvas
-        IEEE addresses are skipped.
+        ``zigbee.parse_networkmap``. Already-pending IEEE addresses are skipped;
+        already-approved (on-canvas) devices have their IEEE/Vendor/Model/LQI
+        properties refreshed instead of being re-added.
 
-        Returns: ``{"added": N, "skipped": M}``.
+        Returns: ``{"added": N, "skipped": M, "refreshed": K}``.
         """
         pending = await self._get_pending()
         canvas = await self.get_canvas()
@@ -643,11 +660,12 @@ class HomelableCoordinator(DataUpdateCoordinator):
         # IEEE addresses already represented anywhere — avoid duplicates.
         # Canvas nodes may be flat (top-level ieee_address) or nested under
         # `data`; read both so an approved zigbee node isn't re-imported.
-        on_canvas = {
-            ieee
+        canvas_by_ieee = {
+            ieee: n
             for n in canvas.get("nodes", [])
             if (ieee := n.get("ieee_address") or n.get("data", {}).get("ieee_address"))
         }
+        on_canvas = set(canvas_by_ieee)
         already_pending = {
             d.get("data_extras", {}).get("ieee_address")
             for d in pending["devices"]
@@ -657,10 +675,27 @@ class HomelableCoordinator(DataUpdateCoordinator):
 
         added = 0
         skipped = 0
+        refreshed = 0
         now = _utc_now_iso()
         for dev in devices:
             ieee = dev.get("ieee_address") or dev.get("id")
-            if not ieee or ieee in existing:
+            if not ieee:
+                skipped += 1
+                continue
+            # Already approved onto the canvas: refresh its IEEE/Vendor/Model/LQI
+            # props (preserving the user's visibility choices) and skip creating
+            # a pending row, so approved devices stay out of pending/hidden.
+            node = canvas_by_ieee.get(ieee)
+            if node is not None:
+                props = zigbee.build_zigbee_properties(
+                    ieee, dev.get("vendor"), dev.get("model"), dev.get("lqi")
+                )
+                node["properties"] = zigbee.merge_zigbee_properties(
+                    node.get("properties"), props
+                )
+                refreshed += 1
+                continue
+            if ieee in existing:
                 skipped += 1
                 continue
             pending["devices"].append(
@@ -693,4 +728,6 @@ class HomelableCoordinator(DataUpdateCoordinator):
 
         if added:
             await self._save_pending()
-        return {"added": added, "skipped": skipped}
+        if refreshed:
+            await self.save_canvas(canvas)
+        return {"added": added, "skipped": skipped, "refreshed": refreshed}

--- a/custom_components/homelable/zigbee.py
+++ b/custom_components/homelable/zigbee.py
@@ -27,6 +27,54 @@ class ZigbeeMqttNotReadyError(RuntimeError):
     """HA MQTT integration not loaded / not configured."""
 
 
+def build_zigbee_properties(
+    ieee: str | None,
+    vendor: str | None,
+    model: str | None,
+    lqi: int | None,
+) -> list[dict[str, Any]]:
+    """Build a NodeProperty list for a Zigbee device (IEEE, Vendor, Model, LQI).
+
+    Only includes a row when the value is non-empty. Shape matches the
+    frontend ``NodeProperty`` type: ``{key, value, icon, visible}``.
+
+    New props default to ``visible=False`` — users opt in to showing them on
+    the canvas card from the right panel.
+    """
+    props: list[dict[str, Any]] = []
+    if ieee:
+        props.append({"key": "IEEE", "value": ieee, "icon": None, "visible": False})
+    if vendor:
+        props.append({"key": "Vendor", "value": vendor, "icon": None, "visible": False})
+    if model:
+        props.append({"key": "Model", "value": model, "icon": None, "visible": False})
+    if lqi is not None:
+        props.append({"key": "LQI", "value": str(lqi), "icon": None, "visible": False})
+    return props
+
+
+def merge_zigbee_properties(
+    existing: list[dict[str, Any]] | None,
+    new_props: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Merge fresh zigbee props into an existing property list.
+
+    For keys already present: update ``value`` but preserve the user's
+    ``visible`` choice. New keys are appended with whatever visibility the
+    caller gave them (hidden by default per ``build_zigbee_properties``).
+    Non-zigbee custom properties are preserved untouched.
+    """
+    out = [dict(p) for p in (existing or [])]
+    by_key = {p.get("key"): p for p in out}
+    for np in new_props:
+        key = np.get("key")
+        if key in by_key:
+            by_key[key]["value"] = np.get("value")
+        else:
+            out.append(dict(np))
+    return out
+
+
 def _z2m_type_to_homelable(device_type: str) -> str:
     return {
         "Coordinator": "zigbee_coordinator",

--- a/frontend-src/src/components/modals/PendingDevicesModal.tsx
+++ b/frontend-src/src/components/modals/PendingDevicesModal.tsx
@@ -9,6 +9,7 @@ import { useCanvasStore } from '@/stores/canvasStore'
 import { toast } from 'sonner'
 import { PendingDeviceModal, type PendingDevice } from '@/components/modals/PendingDeviceModal'
 import type { NodeType, ServiceInfo } from '@/types'
+import { buildZigbeeProperties, isZigbeeType } from '@/utils/zigbeeProperties'
 
 interface PendingDevicesModalProps {
   open: boolean
@@ -241,13 +242,16 @@ export function PendingDevicesModal({ open, onClose, highlightId, initialStatus 
   const handleApprove = async (device: PendingDevice) => {
     try {
       const fallbackLabel = deviceLabel(device)
+      const type = (device.suggested_type ?? 'generic') as NodeType
+      const zigbee = isZigbeeType(type)
       const nodeData = {
         label: fallbackLabel,
-        type: (device.suggested_type ?? 'generic') as NodeType,
+        type,
         ip: device.ip ?? undefined,
         hostname: device.hostname ?? undefined,
-        status: 'unknown',
+        status: zigbee ? 'online' : 'unknown',
         services: (device.services ?? []) as ServiceInfo[],
+        properties: zigbee ? buildZigbeeProperties(device) : [],
       }
       const res = await scanApi.approve(device.id, nodeData)
       const nodeId = res.data.node_id
@@ -255,7 +259,7 @@ export function PendingDevicesModal({ open, onClose, highlightId, initialStatus 
         id: nodeId,
         type: nodeData.type,
         position: { x: 400, y: 300 },
-        data: { ...nodeData, status: 'unknown' as const },
+        data: { ...nodeData, status: zigbee ? ('online' as const) : ('unknown' as const) },
       })
       injectAutoEdges(res.data.edges)
       const extra = res.data.edges_created > 0 ? ` (+${res.data.edges_created} link${res.data.edges_created !== 1 ? 's' : ''})` : ''
@@ -299,17 +303,20 @@ export function PendingDevicesModal({ open, onClose, highlightId, initialStatus 
       approvedDevices.forEach((d, i) => {
         const nodeId = deviceToNode[d.id]
         if (!nodeId) return
+        const type = (d.suggested_type ?? 'generic') as NodeType
+        const zigbee = isZigbeeType(type)
         addNode({
           id: nodeId,
-          type: (d.suggested_type ?? 'generic') as NodeType,
+          type,
           position: { x: 400 + (i % 4) * 160, y: 300 + Math.floor(i / 4) * 100 },
           data: {
             label: deviceLabel(d),
-            type: (d.suggested_type ?? 'generic') as NodeType,
+            type,
             ip: d.ip ?? undefined,
             hostname: d.hostname ?? undefined,
-            status: 'unknown' as const,
+            status: zigbee ? ('online' as const) : ('unknown' as const),
             services: (d.services ?? []) as ServiceInfo[],
+            properties: zigbee ? buildZigbeeProperties(d) : [],
           },
         })
       })

--- a/frontend-src/src/utils/__tests__/zigbeeProperties.test.ts
+++ b/frontend-src/src/utils/__tests__/zigbeeProperties.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { buildZigbeeProperties, isZigbeeType } from '../zigbeeProperties'
+
+describe('isZigbeeType', () => {
+  it('matches the three zigbee node types', () => {
+    expect(isZigbeeType('zigbee_coordinator')).toBe(true)
+    expect(isZigbeeType('zigbee_router')).toBe(true)
+    expect(isZigbeeType('zigbee_enddevice')).toBe(true)
+  })
+
+  it('rejects non-zigbee and empty values', () => {
+    expect(isZigbeeType('generic')).toBe(false)
+    expect(isZigbeeType('server')).toBe(false)
+    expect(isZigbeeType(undefined)).toBe(false)
+    expect(isZigbeeType(null)).toBe(false)
+    expect(isZigbeeType('')).toBe(false)
+  })
+})
+
+describe('buildZigbeeProperties', () => {
+  it('includes only non-empty fields, all hidden by default', () => {
+    const props = buildZigbeeProperties({
+      ieee_address: '0xABCD',
+      vendor: 'Aqara',
+      model: null,
+      lqi: 200,
+    })
+    expect(props.map((p) => p.key)).toEqual(['IEEE', 'Vendor', 'LQI'])
+    expect(props.every((p) => p.visible === false)).toBe(true)
+    expect(props.every((p) => p.icon === null)).toBe(true)
+    expect(props.find((p) => p.key === 'LQI')?.value).toBe('200')
+  })
+
+  it('keeps lqi of 0 (only null/undefined are missing)', () => {
+    const props = buildZigbeeProperties({ lqi: 0 })
+    expect(props).toEqual([{ key: 'LQI', value: '0', icon: null, visible: false }])
+  })
+
+  it('returns empty array when nothing is set', () => {
+    expect(buildZigbeeProperties({})).toEqual([])
+  })
+
+  it('matches the backend property shape', () => {
+    const props = buildZigbeeProperties({
+      ieee_address: '0x1',
+      vendor: 'V',
+      model: 'M',
+      lqi: 50,
+    })
+    expect(props).toEqual([
+      { key: 'IEEE', value: '0x1', icon: null, visible: false },
+      { key: 'Vendor', value: 'V', icon: null, visible: false },
+      { key: 'Model', value: 'M', icon: null, visible: false },
+      { key: 'LQI', value: '50', icon: null, visible: false },
+    ])
+  })
+})

--- a/frontend-src/src/utils/zigbeeProperties.ts
+++ b/frontend-src/src/utils/zigbeeProperties.ts
@@ -1,0 +1,23 @@
+import type { NodeProperty, NodeType } from '@/types'
+
+const ZIGBEE_TYPES: NodeType[] = ['zigbee_coordinator', 'zigbee_router', 'zigbee_enddevice']
+
+export function isZigbeeType(type: NodeType | string | undefined | null): boolean {
+  return !!type && (ZIGBEE_TYPES as string[]).includes(type)
+}
+
+/** Build the IEEE/Vendor/Model/LQI property rows shown in the right panel.
+ * Matches backend `build_zigbee_properties`. */
+export function buildZigbeeProperties(input: {
+  ieee_address?: string | null
+  vendor?: string | null
+  model?: string | null
+  lqi?: number | null
+}): NodeProperty[] {
+  const props: NodeProperty[] = []
+  if (input.ieee_address) props.push({ key: 'IEEE', value: input.ieee_address, icon: null, visible: false })
+  if (input.vendor) props.push({ key: 'Vendor', value: input.vendor, icon: null, visible: false })
+  if (input.model) props.push({ key: 'Model', value: input.model, icon: null, visible: false })
+  if (input.lqi != null) props.push({ key: 'LQI', value: String(input.lqi), icon: null, visible: false })
+  return props
+}

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -353,6 +353,64 @@ async def test_approve_zigbee_child_links_to_flat_parent(coord) -> None:  # noqa
 
 
 @pytest.mark.asyncio
+async def test_approve_zigbee_attaches_hidden_properties_and_online(coord) -> None:  # noqa: ANN001
+    """Approving a zigbee device builds hidden IEEE/Vendor/Model/LQI props,
+    lands the node online, and sets check_method to none."""
+    pending = await coord._get_pending()
+    pending["devices"].append(
+        {
+            "id": "pd-zb",
+            "ip": None,
+            "mac": None,
+            "hostname": "Sensor",
+            "os": None,
+            "services": [],
+            "suggested_type": "zigbee_enddevice",
+            "source": "zigbee",
+            "status": "pending",
+            "data_extras": {
+                "ieee_address": "0xS1",
+                "vendor": "Aqara",
+                "model": "WSDCGQ11LM",
+                "lqi": 180,
+                "parent_id": None,
+            },
+        }
+    )
+    await coord._save_pending()
+    node = await coord.approve_pending("pd-zb")
+
+    assert node["status"] == "online"
+    assert node["check_method"] == "none"
+    by_key = {p["key"]: p for p in node["properties"]}
+    assert set(by_key) == {"IEEE", "Vendor", "Model", "LQI"}
+    assert all(p["visible"] is False for p in node["properties"])
+    assert by_key["LQI"]["value"] == "180"
+
+
+@pytest.mark.asyncio
+async def test_approve_non_zigbee_has_empty_properties(coord) -> None:  # noqa: ANN001
+    pending = await coord._get_pending()
+    pending["devices"].append(
+        {
+            "id": "pd-ip",
+            "ip": "192.168.1.5",
+            "mac": None,
+            "hostname": "nas",
+            "os": None,
+            "services": [],
+            "suggested_type": "generic",
+            "status": "pending",
+        }
+    )
+    await coord._save_pending()
+    node = await coord.approve_pending("pd-ip")
+    assert node["properties"] == []
+    assert node["status"] == "unknown"
+    assert node["check_method"] == "ping"
+
+
+@pytest.mark.asyncio
 async def test_approve_pending_unknown_returns_none(coord) -> None:  # noqa: ANN001
     assert await coord.approve_pending("nope") is None
 

--- a/tests/test_zigbee.py
+++ b/tests/test_zigbee.py
@@ -129,6 +129,55 @@ async def test_fetch_networkmap_raises_when_mqtt_missing(hass: HomeAssistant) ->
         await zigbee.fetch_networkmap(hass, "zigbee2mqtt", timeout=0.1)
 
 
+# ─── Property builders ───────────────────────────────────────────────────────
+
+
+def test_build_zigbee_properties_includes_only_non_empty() -> None:
+    props = zigbee.build_zigbee_properties("0xABCD", "Aqara", None, 200)
+    keys = [p["key"] for p in props]
+    assert keys == ["IEEE", "Vendor", "LQI"]  # Model omitted (None)
+    assert all(p["visible"] is False for p in props)
+    assert all(p["icon"] is None for p in props)
+    lqi = next(p for p in props if p["key"] == "LQI")
+    assert lqi["value"] == "200"  # stringified
+
+
+def test_build_zigbee_properties_keeps_lqi_zero() -> None:
+    # lqi=0 is a real value (None is the only "missing" sentinel).
+    props = zigbee.build_zigbee_properties(None, None, None, 0)
+    assert props == [{"key": "LQI", "value": "0", "icon": None, "visible": False}]
+
+
+def test_merge_zigbee_properties_preserves_user_visibility() -> None:
+    existing = [
+        {"key": "IEEE", "value": "0xABCD", "icon": None, "visible": True},
+        {"key": "Custom", "value": "mine", "icon": "star", "visible": True},
+    ]
+    new = zigbee.build_zigbee_properties("0xABCD", "Aqara", "WSDCGQ11LM", 180)
+    merged = zigbee.merge_zigbee_properties(existing, new)
+    by_key = {p["key"]: p for p in merged}
+    # Existing IEEE keeps user's visible=True, value unchanged.
+    assert by_key["IEEE"]["visible"] is True
+    # New keys appended hidden.
+    assert by_key["Vendor"]["visible"] is False
+    assert by_key["Model"]["value"] == "WSDCGQ11LM"
+    # Non-zigbee custom prop untouched.
+    assert by_key["Custom"] == existing[1]
+
+
+def test_merge_zigbee_properties_updates_value() -> None:
+    existing = [{"key": "LQI", "value": "100", "icon": None, "visible": True}]
+    new = zigbee.build_zigbee_properties(None, None, None, 250)
+    merged = zigbee.merge_zigbee_properties(existing, new)
+    assert merged[0]["value"] == "250"
+    assert merged[0]["visible"] is True  # visibility preserved
+
+
+def test_merge_zigbee_properties_handles_none_existing() -> None:
+    new = zigbee.build_zigbee_properties("0xABCD", None, None, None)
+    assert zigbee.merge_zigbee_properties(None, new) == new
+
+
 # ─── Coordinator import path ─────────────────────────────────────────────────
 
 
@@ -160,7 +209,7 @@ async def test_import_zigbee_devices_adds_to_pending(coordinator: HomelableCoord
         }
     ]
     result = await coordinator.import_zigbee_devices(devs)
-    assert result == {"added": 1, "skipped": 0}
+    assert result == {"added": 1, "skipped": 0, "refreshed": 0}
     pending = await coordinator.list_pending(source="zigbee")
     assert len(pending) == 1
     # Flattened on the wire.
@@ -182,7 +231,64 @@ async def test_import_zigbee_devices_skips_duplicates(
     }
     await coordinator.import_zigbee_devices([dev])
     result = await coordinator.import_zigbee_devices([dev])
-    assert result == {"added": 0, "skipped": 1}
+    assert result == {"added": 0, "skipped": 1, "refreshed": 0}
+
+
+async def test_import_zigbee_devices_refreshes_approved_canvas_node(
+    coordinator: HomelableCoordinator,
+) -> None:
+    """Re-import of an approved device refreshes its props, preserving the
+    user's visibility choice, and does not re-create a pending row."""
+    # Approve a zigbee device onto the canvas first.
+    await coordinator.import_zigbee_devices(
+        [
+            {
+                "id": "0xR1",
+                "ieee_address": "0xR1",
+                "friendly_name": "Router",
+                "type": "zigbee_router",
+                "device_type": "Router",
+                "model": "E11-N1EA",
+                "vendor": "Sengled",
+                "lqi": 100,
+            }
+        ]
+    )
+    pending = await coordinator.list_pending(source="zigbee")
+    node = await coordinator.approve_pending(pending[0]["id"])
+    assert node is not None
+    # User opts to show LQI on the canvas card.
+    canvas = await coordinator.get_canvas()
+    saved = next(n for n in canvas["nodes"] if n["ieee_address"] == "0xR1")
+    for p in saved["properties"]:
+        if p["key"] == "LQI":
+            p["visible"] = True
+    await coordinator.save_canvas(canvas)
+
+    # Re-import with a new LQI value.
+    result = await coordinator.import_zigbee_devices(
+        [
+            {
+                "id": "0xR1",
+                "ieee_address": "0xR1",
+                "friendly_name": "Router",
+                "type": "zigbee_router",
+                "device_type": "Router",
+                "model": "E11-N1EA",
+                "vendor": "Sengled",
+                "lqi": 250,
+            }
+        ]
+    )
+    assert result == {"added": 0, "skipped": 0, "refreshed": 1}
+    # No new pending row created.
+    assert await coordinator.list_pending(source="zigbee") == []
+    # Props refreshed, visibility preserved.
+    canvas = await coordinator.get_canvas()
+    refreshed = next(n for n in canvas["nodes"] if n["ieee_address"] == "0xR1")
+    lqi = next(p for p in refreshed["properties"] if p["key"] == "LQI")
+    assert lqi["value"] == "250"
+    assert lqi["visible"] is True
 
 
 # ─── WS commands ─────────────────────────────────────────────────────────────
@@ -227,7 +333,7 @@ async def test_ws_zigbee_import_pushes_to_pending(
     )
     msg = await client.receive_json()
     assert msg["success"] is True
-    assert msg["result"] == {"added": 1, "skipped": 0}
+    assert msg["result"] == {"added": 1, "skipped": 0, "refreshed": 0}
 
 
 async def test_ws_zigbee_devices_happy_path_with_mocked_mqtt(


### PR DESCRIPTION
Port of the HA-relevant parts of standalone [homelable#148](https://github.com/Pouzor/homelable/pull/148).

## What
- **`zigbee.py`**: `build_zigbee_properties()` + `merge_zigbee_properties()` (pure dict helpers, no SQLAlchemy).
- **`coordinator.approve_pending`**: zigbee devices land `online` and carry IEEE/Vendor/Model/LQI as right-panel property rows, hidden by default (users opt in to showing them on the canvas card). `check_method="none"` already existed.
- **`coordinator.import_zigbee_devices`**: re-import of an already-approved canvas node now *refreshes* its props — merging new values while preserving the user's `visible` choices — instead of plain-skipping. Returns a new `refreshed` count and re-saves the canvas.
- **Frontend**: `utils/zigbeeProperties.ts` (`isZigbeeType`, `buildZigbeeProperties`) + `PendingDevicesModal` wiring so single and bulk approve set `online` status and attach properties.

## Omitted from the source PR (by design)
- passlib→bcrypt swap, `hash_password.py`, `test_auth` — HA owns authentication; this repo has no auth code.
- status_checker CLI-flag (`-`) guard — the hacs status checker already resolves every host to an IP before invoking ping/tcp.
- NodeModal `parentContainerNodes` removal — tangential refactor unrelated to the zigbee feature.

## Tests
- `tests/test_zigbee.py`: helper unit tests + re-import-refresh-preserves-visibility; updated existing assertions for the new `refreshed` key.
- `tests/test_coordinator.py`: zigbee approve attaches hidden props + online + none; non-zigbee approve has empty props.
- `frontend-src/.../zigbeeProperties.test.ts`: 6 vitest cases.

`pytest` 118 passed · `tsc` clean · `eslint` 0 errors.