### PR TITLE
fix(status): ping check target with a URL no longer reports devices offline

### DIFF
--- a/custom_components/homelable/status_checker.py
+++ b/custom_components/homelable/status_checker.py
@@ -54,6 +54,18 @@ def _extract_host(value: str) -> str:
     return value
 
 
+def _extract_port(value: str, default: int) -> int:
+    """Pull a port out of a `host:port` or URL target; fall back to default."""
+    if "://" in value:
+        parsed = urlparse(value)
+        return parsed.port or default
+    if value.count(":") == 1 and ":" in value:
+        _, _, port_str = value.rpartition(":")
+        if port_str.isdigit():
+            return int(port_str)
+    return default
+
+
 def _resolve_to_ip(host: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
     """Return the resolved IP for a host string, or None on failure."""
     if not host:
@@ -128,32 +140,37 @@ async def check_node(
     try:
         match check_method:
             case "ping":
-                if not _host_is_allowed(host, nets):
+                # The target may be a bare host, host:port, or a URL (the node
+                # editor's placeholder suggests `http://...`). Strip everything
+                # but the host so resolution + ping don't choke on the scheme.
+                final_host = _extract_host(host) or host
+                if not _host_is_allowed(final_host, nets):
                     return {"status": "offline", "response_time_ms": None}
-                ok = await _ping(host)
+                ok = await _ping(final_host)
             case "http":
                 ok = await _http_check(host, "http", nets)
             case "https":
                 ok = await _http_check(host, "https", nets)
             case "tcp":
-                host_part, _, port_str = host.rpartition(":")
-                port = int(port_str) if port_str.isdigit() else 80
-                final_host = host_part or host
+                final_host = _extract_host(host) or host
+                port = _extract_port(host, 80)
                 if not _host_is_allowed(final_host, nets):
                     return {"status": "offline", "response_time_ms": None}
                 ok = await _tcp_connect(final_host, port)
             case "ssh":
-                if not _host_is_allowed(host, nets):
+                final_host = _extract_host(host) or host
+                if not _host_is_allowed(final_host, nets):
                     return {"status": "offline", "response_time_ms": None}
-                ok = await _tcp_connect(host, 22)
+                ok = await _tcp_connect(final_host, 22)
             case "prometheus":
                 ok = await _http_check(host, "http", nets, default_path="/metrics")
             case "health":
                 ok = await _http_check(host, "http", nets, default_path="/health")
             case _:
-                if not _host_is_allowed(host, nets):
+                final_host = _extract_host(host) or host
+                if not _host_is_allowed(final_host, nets):
                     return {"status": "offline", "response_time_ms": None}
-                ok = await _ping(host)
+                ok = await _ping(final_host)
 
         elapsed_ms = int((time.monotonic() - start) * 1000)
         return {

--- a/frontend-src/src/components/modals/NodeModal.tsx
+++ b/frontend-src/src/components/modals/NodeModal.tsx
@@ -34,6 +34,20 @@ const CHECK_METHOD_LABELS: Record<CheckMethod, string> = {
   health: 'Health',
 }
 
+// Ping/SSH probe a bare host; tcp wants host:port; http-family wants a URL.
+// A misleading `http://...` placeholder makes users enter a URL for ping,
+// which then fails to resolve and reports the device offline.
+const CHECK_TARGET_PLACEHOLDERS: Record<CheckMethod, string> = {
+  none: '',
+  ping: '192.168.1.10 (defaults to node IP)',
+  http: 'http://192.168.1.10:8080',
+  https: 'https://192.168.1.10:8443',
+  tcp: '192.168.1.10:5432',
+  ssh: '192.168.1.10 (defaults to node IP)',
+  prometheus: 'http://192.168.1.10:9090',
+  health: 'http://192.168.1.10:8080',
+}
+
 const DEFAULT_DATA: Partial<NodeData> = {
   type: 'server',
   label: '',
@@ -307,7 +321,7 @@ export function NodeModal({ open, onClose, onSubmit, initial, title = 'Add Node'
                   <Input
                     value={form.check_target ?? ''}
                     onChange={(e) => set('check_target', e.target.value)}
-                    placeholder="http://..."
+                    placeholder={CHECK_TARGET_PLACEHOLDERS[(form.check_method ?? 'ping') as CheckMethod]}
                     className={`bg-[#21262d] border-[#30363d] font-mono text-sm h-8 ${modalStyles['modal-radius']}`}
                   />
                 </div>

--- a/frontend-src/src/components/modals/__tests__/NodeModal.test.tsx
+++ b/frontend-src/src/components/modals/__tests__/NodeModal.test.tsx
@@ -169,9 +169,19 @@ describe('NodeModal', () => {
 
   it('submits check_target', () => {
     const { onSubmit } = renderModal({ initial: BASE })
-    fireEvent.change(screen.getByPlaceholderText('http://...'), { target: { value: 'http://192.168.1.10:8080' } })
+    fireEvent.change(screen.getByPlaceholderText('192.168.1.10 (defaults to node IP)'), { target: { value: 'http://192.168.1.10:8080' } })
     fireEvent.click(screen.getByRole('button', { name: 'Add' }))
     expect((onSubmit.mock.calls[0][0] as Partial<NodeData>).check_target).toBe('http://192.168.1.10:8080')
+  })
+
+  it('uses a method-specific check target placeholder', () => {
+    renderModal({ initial: BASE })
+    expect(screen.getByPlaceholderText('192.168.1.10 (defaults to node IP)')).toBeInTheDocument()
+  })
+
+  it('uses a URL check target placeholder for http-family methods', () => {
+    renderModal({ initial: { ...BASE, check_method: 'https' } })
+    expect(screen.getByPlaceholderText('https://192.168.1.10:8443')).toBeInTheDocument()
   })
 
   // ── Type selector ─────────────────────────────────────────────────────

--- a/tests/test_status_checker.py
+++ b/tests/test_status_checker.py
@@ -65,6 +65,43 @@ async def test_check_ip_first_value_when_comma_separated() -> None:
 
 
 @pytest.mark.asyncio
+async def test_check_ping_strips_url_target() -> None:
+    """A URL typed into a ping target is reduced to its host before pinging.
+
+    Regression for #24: the `http://...` placeholder leads users to enter a
+    URL even for ping checks; the scheme used to break resolution and the
+    device was wrongly reported offline.
+    """
+    with patch.object(status_checker, "_ping", AsyncMock(return_value=True)) as mock:
+        await status_checker.check_node("ping", "http://192.168.1.10:8080", None)
+    mock.assert_awaited_once_with("192.168.1.10")
+
+
+@pytest.mark.asyncio
+async def test_check_ping_strips_host_port_target() -> None:
+    """A `host:port` ping target is reduced to the bare host."""
+    with patch.object(status_checker, "_ping", AsyncMock(return_value=True)) as mock:
+        await status_checker.check_node("ping", "host.local:8080", None)
+    mock.assert_awaited_once_with("host.local")
+
+
+@pytest.mark.asyncio
+async def test_check_ssh_strips_url_target() -> None:
+    """SSH target with a scheme is reduced to the host before connecting."""
+    with patch.object(status_checker, "_tcp_connect", AsyncMock(return_value=True)) as mock:
+        await status_checker.check_node("ssh", "ssh://10.0.0.1", None)
+    mock.assert_awaited_once_with("10.0.0.1", 22)
+
+
+@pytest.mark.asyncio
+async def test_check_tcp_parses_url_port() -> None:
+    """tcp check pulls the port from a full URL target."""
+    with patch.object(status_checker, "_tcp_connect", AsyncMock(return_value=True)) as mock:
+        await status_checker.check_node("tcp", "http://host:8080/path", None)
+    mock.assert_awaited_once_with("host", 8080)
+
+
+@pytest.mark.asyncio
 async def test_check_http_prepends_scheme() -> None:
     """http check adds http:// when target lacks scheme."""
     with patch.object(status_checker, "_http_get", AsyncMock(return_value=True)) as mock:


### PR DESCRIPTION
## Problem

Fixes #24. Devices were reported **offline even though online** as soon as anything was entered in **Check Target**; leaving it blank worked.

## Root cause

The node editor's Check Target placeholder was `http://...`, so users entered a URL even for `ping` checks. In `status_checker.check_node`, the `ping` (and `ssh`, fallback) branches passed the raw target straight to `_host_is_allowed` / `_ping` **without** running `_extract_host` first. A value like `http://192.168.1.10` then failed `socket.getaddrinfo`, so `_host_is_allowed` returned `False` and the device was marked offline regardless of reachability. The `http`/`https`/`prometheus`/`health` branches already normalised via `_extract_host`; `ping`/`ssh`/`tcp` did not.

Blank target worked because the coordinator falls back to the scanned bare IP.

## Fix

- `status_checker.py`: normalise the target with `_extract_host` before resolving/probing in the `ping`, `ssh`, `tcp` and fallback branches; add `_extract_port` so `tcp` reads the port from a `host:port` or full URL.
- `NodeModal.tsx`: method-aware Check Target placeholder — bare host for ping/ssh (noting it defaults to the node IP), `host:port` for tcp, URL for http-family.

## Tests

- New `status_checker` cases: URL/`host:port` ping target stripped to host, ssh URL target, tcp URL port parsing.
- New `NodeModal` cases: placeholder is method-specific.
- Full `pytest` (122) and `vitest` (98) suites pass; ruff + eslint clean.