### PR TITLE
feat(canvas): edge endpoint reconnect + proxmox container snap points

### DIFF
--- a/frontend-src/src/components/canvas/edges/index.tsx
+++ b/frontend-src/src/components/canvas/edges/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 import {
   BaseEdge,
   EdgeLabelRenderer,
@@ -179,9 +179,113 @@ function segmentMidpoints(
   })
 }
 
+// ── Endpoint dot (interactive reconnection handle pinned to handle) ──────────
+
+interface EndpointDotProps {
+  edgeId: string
+  role: 'source' | 'target'
+  x: number
+  y: number
+  position?: string
+  color: string
+  source: string
+  target: string
+  sourceHandle: string | null | undefined
+  targetHandle: string | null | undefined
+  onDrag: (pos: { x: number; y: number } | null) => void
+}
+
+/**
+ * Interactive endpoint marker rendered above the node layer (via
+ * EdgeLabelRenderer). On pointerup it inspects the element under the cursor
+ * for a React Flow handle (`[data-handleid]`) and calls `reconnectEdge` with
+ * the new endpoint. Drop on empty space leaves the edge unchanged.
+ *
+ * Handles are nudged 3px inward (toward the node) because React Flow's edge
+ * endpoint coords sit at the outer edge of the handle box, not its center.
+ */
+function EndpointDot({ edgeId, role, x, y, position, color, source, target, sourceHandle, targetHandle, onDrag }: EndpointDotProps) {
+  const reconnectEdge = useCanvasStore((s) => s.reconnectEdge)
+  const { screenToFlowPosition } = useReactFlow()
+
+  const offset = 3
+  let dx = 0, dy = 0
+  if (position === 'bottom') dy = -offset
+  else if (position === 'top') dy = offset
+  else if (position === 'left') dx = offset
+  else if (position === 'right') dx = -offset
+
+  const onPointerDown = useCallback((e: React.PointerEvent) => {
+    e.stopPropagation()
+    e.currentTarget.setPointerCapture(e.pointerId)
+  }, [])
+
+  const onPointerMove = useCallback((e: React.PointerEvent) => {
+    if (e.buttons !== 1) return
+    onDrag(screenToFlowPosition({ x: e.clientX, y: e.clientY }))
+  }, [onDrag, screenToFlowPosition])
+
+  const onPointerUp = useCallback((e: React.PointerEvent) => {
+    e.currentTarget.releasePointerCapture(e.pointerId)
+    // Find the topmost handle under cursor, skipping the dragged dot itself.
+    const stack = document.elementsFromPoint(e.clientX, e.clientY)
+    let handleEl: HTMLElement | null = null
+    for (const node of stack) {
+      const h = (node as HTMLElement).closest?.('[data-handleid]') as HTMLElement | null
+      if (h) { handleEl = h; break }
+    }
+    onDrag(null)
+    if (!handleEl) return  // dropped on empty space → keep edge unchanged
+    const newHandleId = handleEl.getAttribute('data-handleid')
+    const newNodeId = handleEl.getAttribute('data-nodeid')
+    if (!newHandleId || !newNodeId) return
+    if (role === 'source') {
+      reconnectEdge(edgeId, { source: newNodeId, target, sourceHandle: newHandleId, targetHandle: targetHandle ?? null })
+    } else {
+      reconnectEdge(edgeId, { source, target: newNodeId, sourceHandle: sourceHandle ?? null, targetHandle: newHandleId })
+    }
+  }, [edgeId, role, source, target, sourceHandle, targetHandle, reconnectEdge, onDrag])
+
+  return (
+    <div
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      style={{
+        position: 'absolute',
+        transform: `translate(-50%, -50%) translate(${x + dx}px, ${y + dy}px)`,
+        width: 15,
+        height: 15,
+        borderRadius: '50%',
+        background: color,
+        border: '2px solid #0d1117',
+        cursor: 'grab',
+        pointerEvents: 'all',
+        zIndex: 1000,
+        touchAction: 'none',
+      }}
+      title="Drag to reconnect"
+    />
+  )
+}
+
 // ── Main edge component ──────────────────────────────────────────────────────
 
-export function HomelableEdge({ id, source, target, sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition, data, selected }: EdgeProps<Edge<EdgeData>>) {
+export function HomelableEdge({ id, source, target, sourceHandleId, targetHandleId, sourceX: rawSourceX, sourceY: rawSourceY, targetX: rawTargetX, targetY: rawTargetY, sourcePosition, targetPosition, data, selected }: EdgeProps<Edge<EdgeData>>) {
+  const [drag, setDrag] = useState<{ role: 'source' | 'target'; x: number; y: number } | null>(null)
+
+  const sourceX = drag?.role === 'source' ? drag.x : rawSourceX
+  const sourceY = drag?.role === 'source' ? drag.y : rawSourceY
+  const targetX = drag?.role === 'target' ? drag.x : rawTargetX
+  const targetY = drag?.role === 'target' ? drag.y : rawTargetY
+
+  const onSourceDrag = useCallback((pos: { x: number; y: number } | null) => {
+    setDrag(pos ? { role: 'source', x: pos.x, y: pos.y } : null)
+  }, [])
+  const onTargetDrag = useCallback((pos: { x: number; y: number } | null) => {
+    setDrag(pos ? { role: 'target', x: pos.x, y: pos.y } : null)
+  }, [])
+
   const activeTheme = useThemeStore((s) => s.activeTheme)
   const theme = THEMES[activeTheme]
   const sourceType = useStore((s) => s.nodeLookup.get(source)?.type)
@@ -310,6 +414,38 @@ export function HomelableEdge({ id, source, target, sourceX, sourceY, targetX, t
           >
             {data.label as string}
           </div>
+        )}
+
+        {/* Endpoint dots — visual indicators for reconnection targets */}
+        {selected && (
+          <>
+            <EndpointDot
+              edgeId={id}
+              role="source"
+              x={sourceX}
+              y={sourceY}
+              position={sourcePosition}
+              color={strokeColor}
+              source={source}
+              target={target}
+              sourceHandle={sourceHandleId}
+              targetHandle={targetHandleId}
+              onDrag={onSourceDrag}
+            />
+            <EndpointDot
+              edgeId={id}
+              role="target"
+              x={targetX}
+              y={targetY}
+              position={targetPosition}
+              color={strokeColor}
+              source={source}
+              target={target}
+              sourceHandle={sourceHandleId}
+              targetHandle={targetHandleId}
+              onDrag={onTargetDrag}
+            />
+          </>
         )}
 
         {/* Existing waypoint drag handles */}

--- a/frontend-src/src/components/canvas/edges/index.tsx
+++ b/frontend-src/src/components/canvas/edges/index.tsx
@@ -227,15 +227,29 @@ function EndpointDot({ edgeId, role, x, y, position, color, source, target, sour
 
   const onPointerUp = useCallback((e: React.PointerEvent) => {
     e.currentTarget.releasePointerCapture(e.pointerId)
-    // Find the topmost handle under cursor, skipping the dragged dot itself.
-    const stack = document.elementsFromPoint(e.clientX, e.clientY)
+    // Snap to the nearest handle within SNAP_RADIUS rather than requiring the
+    // cursor to land dead-on the (tiny) handle box. We scan every handle in the
+    // root and pick the closest center, filtered to the matching endpoint type
+    // (source endpoints snap to source handles, targets to target handles) so a
+    // dot never lands on the invisible overlapping `-t` handle.
+    //
+    // The root is resolved via `getRootNode()`: in Home Assistant the panel is
+    // mounted in a Shadow DOM, so `document.querySelectorAll` never sees the
+    // handles. `getRootNode()` returns the enclosing ShadowRoot (or Document
+    // standalone), both of which expose querySelectorAll over their own tree.
+    const SNAP_RADIUS = 60  // screen px — zoom-independent (getBoundingClientRect is screen space)
+    const root = e.currentTarget.getRootNode() as Document | ShadowRoot
+    const wantClass = role === 'source' ? 'source' : 'target'
     let handleEl: HTMLElement | null = null
-    for (const node of stack) {
-      const h = (node as HTMLElement).closest?.('[data-handleid]') as HTMLElement | null
-      if (h) { handleEl = h; break }
-    }
+    let bestDist = SNAP_RADIUS
+    root.querySelectorAll<HTMLElement>('[data-handleid]').forEach((h) => {
+      if (!h.classList.contains(wantClass)) return
+      const r = h.getBoundingClientRect()
+      const d = Math.hypot(r.left + r.width / 2 - e.clientX, r.top + r.height / 2 - e.clientY)
+      if (d < bestDist) { bestDist = d; handleEl = h }
+    })
     onDrag(null)
-    if (!handleEl) return  // dropped on empty space → keep edge unchanged
+    if (!handleEl) return  // no handle within range → keep edge unchanged
     const newHandleId = handleEl.getAttribute('data-handleid')
     const newNodeId = handleEl.getAttribute('data-nodeid')
     if (!newHandleId || !newNodeId) return
@@ -254,11 +268,11 @@ function EndpointDot({ edgeId, role, x, y, position, color, source, target, sour
       style={{
         position: 'absolute',
         transform: `translate(-50%, -50%) translate(${x + dx}px, ${y + dy}px)`,
-        width: 15,
-        height: 15,
+        width: 11,
+        height: 11,
         borderRadius: '50%',
         background: color,
-        border: '2px solid #0d1117',
+        border: '1.5px solid #0d1117',
         cursor: 'grab',
         pointerEvents: 'all',
         zIndex: 1000,

--- a/frontend-src/src/components/canvas/nodes/ProxmoxGroupNode.tsx
+++ b/frontend-src/src/components/canvas/nodes/ProxmoxGroupNode.tsx
@@ -1,5 +1,5 @@
-import { createElement } from 'react'
-import { Handle, Position, NodeResizer, type NodeProps, type Node } from '@xyflow/react'
+import { createElement, useEffect } from 'react'
+import { Handle, Position, NodeResizer, useUpdateNodeInternals, type NodeProps, type Node } from '@xyflow/react'
 import { Layers } from 'lucide-react'
 import type { NodeData } from '@/types'
 import { resolveNodeColors } from '@/utils/nodeColors'
@@ -10,10 +10,13 @@ import { useCanvasStore } from '@/stores/canvasStore'
 import { maskIp, splitIps } from '@/utils/maskIp'
 import { useThemeStore } from '@/stores/themeStore'
 import { THEMES } from '@/utils/themes'
+import { bottomHandleId, bottomHandlePositions } from '@/utils/handleUtils'
 import { BaseNode } from './BaseNode'
 
 export function ProxmoxGroupNode(props: NodeProps<Node<NodeData>>) {
-  const { data, selected } = props
+  const { id, data, selected } = props
+  const updateNodeInternals = useUpdateNodeInternals()
+  useEffect(() => { updateNodeInternals(id) }, [data.bottom_handles, id, updateNodeInternals])
 
   const activeTheme = useThemeStore((s) => s.activeTheme)
   const hideIp = useCanvasStore((s) => s.hideIp)
@@ -150,13 +153,26 @@ export function ProxmoxGroupNode(props: NodeProps<Node<NodeData>>) {
         style={{ background: theme.colors.handleBackground, borderColor: theme.colors.handleBorder }}
       />
       <Handle type="target" position={Position.Top} id="top-t" style={{ opacity: 0, width: 12, height: 12 }} />
-      <Handle
-        type="source"
-        position={Position.Bottom}
-        id="bottom"
-        style={{ background: theme.colors.handleBackground, borderColor: theme.colors.handleBorder }}
-      />
-      <Handle type="target" position={Position.Bottom} id="bottom-t" style={{ opacity: 0, width: 12, height: 12 }} />
+      {bottomHandlePositions(data.bottom_handles ?? 1).map((leftPct, idx) => {
+        const sourceId = bottomHandleId(idx)
+        const targetId = `${sourceId}-t`
+        return (
+          <span key={sourceId}>
+            <Handle
+              type="source"
+              position={Position.Bottom}
+              id={sourceId}
+              style={{ left: `${leftPct}%`, background: theme.colors.handleBackground, borderColor: theme.colors.handleBorder }}
+            />
+            <Handle
+              type="target"
+              position={Position.Bottom}
+              id={targetId}
+              style={{ left: `${leftPct}%`, opacity: 0, width: 12, height: 12 }}
+            />
+          </span>
+        )
+      })}
 
       {/* Cluster handles */}
       <Handle

--- a/frontend-src/src/components/canvas/nodes/__tests__/ProxmoxGroupNode.test.tsx
+++ b/frontend-src/src/components/canvas/nodes/__tests__/ProxmoxGroupNode.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { ReactFlowProvider } from '@xyflow/react'
+import { ProxmoxGroupNode } from '../ProxmoxGroupNode'
+import { useCanvasStore } from '@/stores/canvasStore'
+import { useThemeStore } from '@/stores/themeStore'
+import type { NodeData, NodeProperty } from '@/types'
+import type { NodeProps, Node } from '@xyflow/react'
+
+function renderNode(data: Partial<NodeData> = {}, selected = false) {
+  const fullData: NodeData = {
+    label: 'pve-01',
+    type: 'proxmox',
+    status: 'online',
+    services: [],
+    ...data,
+  }
+  const props = {
+    id: 'p1',
+    data: fullData,
+    selected,
+    type: 'proxmox',
+    zIndex: 0,
+    isConnectable: true,
+    xPos: 0,
+    yPos: 0,
+    dragging: false,
+    deletable: true,
+    draggable: true,
+    selectable: true,
+    positionAbsoluteX: 0,
+    positionAbsoluteY: 0,
+    width: 300,
+    height: 200,
+    dragHandle: undefined,
+    parentId: undefined,
+    sourcePosition: undefined,
+    targetPosition: undefined,
+  } as unknown as NodeProps<Node<NodeData>>
+  return render(
+    <ReactFlowProvider>
+      <ProxmoxGroupNode {...props} />
+    </ReactFlowProvider>
+  )
+}
+
+describe('ProxmoxGroupNode', () => {
+  beforeEach(() => {
+    useCanvasStore.setState({ hideIp: false })
+    useThemeStore.setState({ activeTheme: 'default' })
+  })
+
+  it('renders the node label', () => {
+    const { getByText } = renderNode({ label: 'My Proxmox' })
+    expect(getByText('My Proxmox')).toBeDefined()
+  })
+
+  it('renders ip when provided', () => {
+    const { getByText } = renderNode({ ip: '192.168.1.10' })
+    expect(getByText('192.168.1.10')).toBeDefined()
+  })
+
+  it('renders multiple ips when comma separated', () => {
+    const { getByText } = renderNode({ ip: '10.0.0.1, 10.0.0.2' })
+    expect(getByText('10.0.0.1')).toBeDefined()
+    expect(getByText('10.0.0.2')).toBeDefined()
+  })
+
+  it('masks ip when hideIp is enabled in store', () => {
+    useCanvasStore.setState({ hideIp: true })
+    const { queryByText } = renderNode({ ip: '192.168.1.10' })
+    expect(queryByText('192.168.1.10')).toBeNull()
+  })
+
+  it('renders visible properties only', () => {
+    const properties: NodeProperty[] = [
+      { key: 'CPU', value: '16 cores', icon: null, visible: true },
+      { key: 'Hidden', value: 'should-not-show', icon: null, visible: false },
+    ]
+    const { getByText, queryByText } = renderNode({ properties })
+    expect(getByText('CPU')).toBeDefined()
+    expect(getByText(/16 cores/)).toBeDefined()
+    expect(queryByText('Hidden')).toBeNull()
+    expect(queryByText(/should-not-show/)).toBeNull()
+  })
+
+  it('renders status dot with title matching status', () => {
+    const { container } = renderNode({ status: 'offline' })
+    const dot = container.querySelector('[title="offline"]')
+    expect(dot).not.toBeNull()
+  })
+
+  it('container_mode === false renders as BaseNode (no resizer group border)', () => {
+    const { container } = renderNode({ container_mode: false })
+    // NodeResizer should not be present when not group-rendered
+    expect(container.querySelector('.react-flow__resize-control')).toBeNull()
+  })
+
+  it('container_mode default renders the group border container', () => {
+    const { container } = renderNode({})
+    // Group border div has rounded-xl border-2 classes
+    expect(container.querySelector('.rounded-xl.border-2')).not.toBeNull()
+  })
+
+  it('container mode renders bottom_handles snap points', () => {
+    const { container } = renderNode({ bottom_handles: 4 })
+    const sourceHandles = container.querySelectorAll('.react-flow__handle-bottom.source')
+    expect(sourceHandles.length).toBe(4)
+  })
+
+  it('container mode default has single bottom handle', () => {
+    const { container } = renderNode({})
+    const sourceHandles = container.querySelectorAll('.react-flow__handle-bottom.source')
+    expect(sourceHandles.length).toBe(1)
+  })
+
+  it('renders cluster handles in both modes', () => {
+    const { container: groupC } = renderNode({})
+    expect(groupC.querySelectorAll('[title="Same cluster"]').length).toBeGreaterThanOrEqual(2)
+    const { container: nodeC } = renderNode({ container_mode: false })
+    expect(nodeC.querySelectorAll('[title="Same cluster"]').length).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/frontend-src/src/index.css
+++ b/frontend-src/src/index.css
@@ -11,6 +11,13 @@
   to   { stroke-dashoffset: 0; }
 }
 
+/* Disable React Flow's built-in edgeupdater entirely — HomelableEdge renders
+   its own interactive endpoint dots in EdgeLabelRenderer (above the node
+   layer) so the node Handle DOM cannot steal the reconnection drag. */
+.react-flow__edgeupdater {
+  display: none;
+}
+
 /* Homelable dark theme — always dark */
 :root {
     --background: #0d1117;

--- a/frontend-src/src/stores/__tests__/canvasStore.test.ts
+++ b/frontend-src/src/stores/__tests__/canvasStore.test.ts
@@ -497,6 +497,31 @@ describe('canvasStore', () => {
     expect(useCanvasStore.getState().hasUnsavedChanges).toBe(true)
   })
 
+  it('reconnectEdge swaps source/target and normalizes handles', () => {
+    useCanvasStore.setState((s) => ({
+      edges: [...s.edges, { ...makeEdge('e1', 'n1', 'n2'), sourceHandle: 'bottom', targetHandle: 'top' }],
+    }))
+    useCanvasStore.getState().markSaved()
+    useCanvasStore.getState().reconnectEdge('e1', {
+      source: 'n1',
+      target: 'n3',
+      sourceHandle: 'bottom-2-t',
+      targetHandle: 'top-t',
+    })
+    const edge = useCanvasStore.getState().edges.find((e) => e.id === 'e1')
+    expect(edge?.target).toBe('n3')
+    expect(edge?.source).toBe('n1')
+    expect(edge?.sourceHandle).toBe('bottom-2')
+    expect(edge?.targetHandle).toBe('top')
+    expect(useCanvasStore.getState().hasUnsavedChanges).toBe(true)
+  })
+
+  it('reconnectEdge snapshots history for undo', () => {
+    useCanvasStore.setState((s) => ({ edges: [...s.edges, makeEdge('e1', 'n1', 'n2')], past: [] }))
+    useCanvasStore.getState().reconnectEdge('e1', { source: 'n1', target: 'n3', sourceHandle: null, targetHandle: null })
+    expect(useCanvasStore.getState().past.length).toBe(1)
+  })
+
   it('deleteEdge removes the edge and marks unsaved', () => {
     useCanvasStore.setState((s) => ({ edges: [...s.edges, makeEdge('e1', 'n1', 'n2'), makeEdge('e2', 'n2', 'n3')] }))
     useCanvasStore.getState().markSaved()

--- a/frontend-src/src/stores/canvasStore.ts
+++ b/frontend-src/src/stores/canvasStore.ts
@@ -44,6 +44,7 @@ interface CanvasState {
   updateNode: (id: string, data: Partial<NodeData>) => void
   deleteNode: (id: string) => void
   updateEdge: (id: string, data: Partial<EdgeData>) => void
+  reconnectEdge: (id: string, connection: Connection) => void
   deleteEdge: (id: string) => void
   setProxmoxContainerMode: (proxmoxId: string, enabled: boolean) => void
   setNodeZIndex: (id: string, zIndex: number) => void
@@ -289,6 +290,24 @@ export const useCanvasStore = create<CanvasState>((set) => ({
       edges: state.edges.map((e) =>
         e.id === id ? { ...e, type: data.type ?? e.type, data: { ...e.data, ...data } as EdgeData } : e
       ),
+      hasUnsavedChanges: true,
+    })),
+
+  reconnectEdge: (id, connection) =>
+    set((state) => ({
+      edges: state.edges.map((e) =>
+        e.id === id
+          ? {
+              ...e,
+              source: connection.source ?? e.source,
+              target: connection.target ?? e.target,
+              sourceHandle: normalizeHandle(connection.sourceHandle),
+              targetHandle: normalizeHandle(connection.targetHandle),
+            }
+          : e
+      ),
+      past: [...state.past.slice(-49), { nodes: state.nodes, edges: state.edges }],
+      future: [],
       hasUnsavedChanges: true,
     })),
 


### PR DESCRIPTION
## Summary

Backport of [Pouzor/homelable#150](https://github.com/Pouzor/homelable/pull/150).

- Selected edges expose interactive endpoint dots; drag either end onto any handle (different snap point or different node) to reconnect. Edge follows the cursor live during drag; drop on empty space leaves the edge unchanged.
- Endpoint dots render in `EdgeLabelRenderer` above the node layer and walk the `elementsFromPoint` stack so the underlying handle wins over the dragged dot — the node Handle DOM no longer steals the drag.
- `ProxmoxGroupNode` in container mode now renders the configured `bottom_handles` snap points (was always a single `bottom` handle), matching `BaseNode`.
- New `canvasStore.reconnectEdge` action: swaps source/target/handles via `normalizeHandle`, snapshots history, marks dirty.

## Adaptation notes

- Paths remapped `frontend/src` → `frontend-src/src`. Pure canvas code — no JWT/FastAPI/API-client rewrites needed.
- `handleUtils` (`bottomHandleId` / `bottomHandlePositions` / `normalizeHandle`) and the `Connection` type were already present in this repo; no import changes.
- `ProxmoxGroupNode.test.tsx` did not exist in this repo, so the whole standalone test file was ported (includes the 2 new snap-point tests).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` — 0 errors (only pre-existing `set-state-in-effect` warnings in `Sidebar.tsx` / `PendingDevicesModal.tsx`)
- [x] `npx vitest run` — 852/852 pass (added 2 store tests + 2 ProxmoxGroupNode tests)