### PR TITLE
feat: port group side-handles + LXC docker_container parent (homelable #152, #153)

### DIFF
--- a/frontend-src/src/App.tsx
+++ b/frontend-src/src/App.tsx
@@ -36,7 +36,6 @@ import type { NodeData, EdgeData, CustomStyleDef } from '@/types'
 
 const STANDALONE = import.meta.env.VITE_STANDALONE === 'true'
 const STANDALONE_STORAGE_KEY = 'homelable_canvas'
-const CONTAINER_MODE_TYPES = new Set<NodeData['type']>(['proxmox', 'vm', 'lxc', 'docker_host'])
 
 export default function App() {
   const { loadCanvas, markSaved, markUnsaved, selectedNodeId, selectedNodeIds, addNode, updateNode, deleteNode, onConnect, updateEdge, deleteEdge, setProxmoxContainerMode, setNodeZIndex, editingGroupRectId, setEditingGroupRectId, editingTextId, setEditingTextId, nodes, edges, snapshotHistory, undo, redo, copySelectedNodes, pasteNodes } = useCanvasStore()
@@ -497,9 +496,7 @@ export default function App() {
           onClose={() => setAddNodeOpen(false)}
           onSubmit={handleAddNode}
           title="Add Node"
-          parentContainerNodes={nodes
-            .filter((n) => CONTAINER_MODE_TYPES.has(n.data.type) && n.data.container_mode)
-            .map((n) => ({ id: n.id, label: n.data.label, nodeType: n.data.type }))}
+          parentCandidates={nodes.map((n) => ({ id: n.id, label: n.data.label ?? n.id, type: n.data.type }))}
         />
 
         {/* key forces re-mount when editing a different node, resetting form state */}
@@ -510,9 +507,25 @@ export default function App() {
           onSubmit={handleUpdateNode}
           initial={editNode?.data}
           title="Edit Node"
-          parentContainerNodes={nodes
-            .filter((n) => n.id !== editNodeId && CONTAINER_MODE_TYPES.has(n.data.type) && n.data.container_mode)
-            .map((n) => ({ id: n.id, label: n.data.label, nodeType: n.data.type }))}
+          parentCandidates={(() => {
+            const descendants = new Set<string>()
+            if (editNodeId) {
+              const queue = [editNodeId]
+              while (queue.length) {
+                const id = queue.shift()!
+                for (const n of nodes) {
+                  if (n.data.parent_id === id && !descendants.has(n.id)) {
+                    descendants.add(n.id)
+                    queue.push(n.id)
+                  }
+                }
+              }
+            }
+            return nodes
+              .filter((n) => !descendants.has(n.id))
+              .map((n) => ({ id: n.id, label: n.data.label ?? n.id, type: n.data.type }))
+          })()}
+          currentNodeId={editNodeId ?? undefined}
         />
 
         <EdgeModal

--- a/frontend-src/src/App.tsx
+++ b/frontend-src/src/App.tsx
@@ -7,6 +7,7 @@ import { applyDagreLayout } from '@/utils/layout'
 import { serializeNode, serializeEdge, deserializeApiNode, deserializeApiEdge, type ApiNode, type ApiEdge } from '@/utils/canvasSerializer'
 import { generateUUID } from '@/utils/uuid'
 import { resolveVirtualEdgeParent } from '@/utils/virtualEdgeParent'
+import { planContainerModeEdgeSync } from '@/utils/containerEdgeSync'
 import { generateMarkdownTable } from '@/utils/exportMarkdown'
 import { ExportModal } from '@/components/modals/ExportModal'
 import { exportCanvasToYaml, downloadYaml } from '@/utils/exportYaml'
@@ -312,6 +313,19 @@ export default function App() {
     // If container_mode changed, apply structural changes (children parentId, node dimensions)
     if (typeof data.container_mode === 'boolean') {
       setProxmoxContainerMode(editNodeId, data.container_mode)
+      // Re-express the relationship with domain children: visual nesting when ON,
+      // a virtual edge when OFF. (data.parent_id is untouched by the toggle.)
+      const childIds = nodes.filter((n) => n.data.parent_id === editNodeId).map((n) => n.id)
+      const virtualEdges = edges
+        .filter((e) => e.data?.type === 'virtual')
+        .map((e) => ({ id: e.id, source: e.source, target: e.target }))
+      const { addChildIds, removeEdgeIds } = planContainerModeEdgeSync(
+        editNodeId, data.container_mode, childIds, virtualEdges,
+      )
+      removeEdgeIds.forEach((id) => deleteEdge(id))
+      addChildIds.forEach((childId) =>
+        onConnect({ source: childId, sourceHandle: 'top', target: editNodeId, targetHandle: 'bottom', type: 'virtual' } as unknown as Connection),
+      )
     }
     // Sync virtual edge when parent_id changes on an LXC/VM node
     const nodeType = data.type ?? existingNode?.data.type

--- a/frontend-src/src/App.tsx
+++ b/frontend-src/src/App.tsx
@@ -6,6 +6,7 @@ const LazyCanvas = lazy(() => import('@/components/canvas/LazyCanvas'))
 import { applyDagreLayout } from '@/utils/layout'
 import { serializeNode, serializeEdge, deserializeApiNode, deserializeApiEdge, type ApiNode, type ApiEdge } from '@/utils/canvasSerializer'
 import { generateUUID } from '@/utils/uuid'
+import { resolveVirtualEdgeParent } from '@/utils/virtualEdgeParent'
 import { generateMarkdownTable } from '@/utils/exportMarkdown'
 import { ExportModal } from '@/components/modals/ExportModal'
 import { exportCanvasToYaml, downloadYaml } from '@/utils/exportYaml'
@@ -391,16 +392,14 @@ export default function App() {
     if (edgeData.type === 'virtual') {
       const src = nodes.find((n) => n.id === pendingConnection.source)
       const tgt = nodes.find((n) => n.id === pendingConnection.target)
-      const srcType = src?.data.type as NodeData['type']
-      const tgtType = tgt?.data.type as NodeData['type']
-      if ((srcType === 'lxc' || srcType === 'vm') && CONTAINER_MODE_TYPES.has(tgtType)) {
-        updateNode(pendingConnection.source, { parent_id: pendingConnection.target })
-      } else if (CONTAINER_MODE_TYPES.has(srcType) && (tgtType === 'lxc' || tgtType === 'vm')) {
-        updateNode(pendingConnection.target, { parent_id: pendingConnection.source })
-      } else if (srcType === 'docker_container' && tgtType === 'docker_host') {
-        updateNode(pendingConnection.source, { parent_id: pendingConnection.target })
-      } else if (tgtType === 'docker_container' && srcType === 'docker_host') {
-        updateNode(pendingConnection.target, { parent_id: pendingConnection.source })
+      if (src && tgt) {
+        const assignment = resolveVirtualEdgeParent(
+          { id: src.id, type: src.data.type as NodeData['type'] },
+          { id: tgt.id, type: tgt.data.type as NodeData['type'] },
+        )
+        if (assignment) {
+          updateNode(assignment.childId, { parent_id: assignment.parentId })
+        }
       }
     }
     setPendingConnection(null)

--- a/frontend-src/src/components/canvas/__tests__/GroupNode.test.tsx
+++ b/frontend-src/src/components/canvas/__tests__/GroupNode.test.tsx
@@ -11,6 +11,8 @@ vi.mock('@xyflow/react', () => ({
   NodeResizer: ({ isVisible }: { isVisible: boolean }) => (
     <div data-testid="node-resizer" data-visible={isVisible} />
   ),
+  Handle: () => null,
+  Position: { Top: 'top', Right: 'right', Bottom: 'bottom', Left: 'left' },
   useReactFlow: () => ({}),
 }))
 

--- a/frontend-src/src/components/canvas/nodes/GroupNode.tsx
+++ b/frontend-src/src/components/canvas/nodes/GroupNode.tsx
@@ -1,11 +1,15 @@
 import { useState } from 'react'
-import { type NodeProps, type Node, NodeResizer } from '@xyflow/react'
+import { type NodeProps, type Node, NodeResizer, Handle, Position } from '@xyflow/react'
 import { Layers, Pencil, Check, X } from 'lucide-react'
 import { useCanvasStore } from '@/stores/canvasStore'
+import { useThemeStore } from '@/stores/themeStore'
+import { THEMES } from '@/utils/themes'
 import { STATUS_COLORS, type NodeData } from '@/types'
 
 export function GroupNode({ id, data, selected }: NodeProps<Node<NodeData>>) {
   const { nodes, updateNode, snapshotHistory } = useCanvasStore()
+  const activeTheme = useThemeStore((s) => s.activeTheme)
+  const theme = THEMES[activeTheme]
   const showBorder = data.custom_colors?.show_border !== false
   const isVisible = showBorder || selected
 
@@ -48,6 +52,29 @@ export function GroupNode({ id, data, selected }: NodeProps<Node<NodeData>>) {
         lineStyle={{ stroke: '#00d4ff', strokeWidth: 1 }}
         handleStyle={{ fill: '#00d4ff', stroke: '#0d1117', width: 8, height: 8, borderRadius: 2 }}
       />
+
+      {/* 4 snap-point handles — one per side. Source + invisible target overlay for each. */}
+      {([
+        ['group-top', Position.Top],
+        ['group-right', Position.Right],
+        ['group-bottom', Position.Bottom],
+        ['group-left', Position.Left],
+      ] as const).map(([hid, pos]) => (
+        <span key={hid}>
+          <Handle
+            type="source"
+            position={pos}
+            id={hid}
+            style={{ background: theme.colors.handleBackground, borderColor: theme.colors.handleBorder }}
+          />
+          <Handle
+            type="target"
+            position={pos}
+            id={`${hid}-t`}
+            style={{ opacity: 0, width: 12, height: 12 }}
+          />
+        </span>
+      ))}
 
       {/* Header */}
       {isVisible && (

--- a/frontend-src/src/components/canvas/nodes/__tests__/GroupNode.test.tsx
+++ b/frontend-src/src/components/canvas/nodes/__tests__/GroupNode.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { ReactFlowProvider } from '@xyflow/react'
+import { GroupNode } from '../GroupNode'
+import { useCanvasStore } from '@/stores/canvasStore'
+import { useThemeStore } from '@/stores/themeStore'
+import type { NodeData } from '@/types'
+import type { NodeProps, Node } from '@xyflow/react'
+
+function renderNode(data: Partial<NodeData> = {}, selected = false) {
+  const fullData: NodeData = {
+    label: 'Group A',
+    type: 'group',
+    status: 'unknown',
+    services: [],
+    ...data,
+  }
+  const props = {
+    id: 'g1',
+    data: fullData,
+    selected,
+    type: 'group',
+    zIndex: 0,
+    isConnectable: true,
+    xPos: 0,
+    yPos: 0,
+    dragging: false,
+    deletable: true,
+    draggable: true,
+    selectable: true,
+    positionAbsoluteX: 0,
+    positionAbsoluteY: 0,
+    width: 300,
+    height: 200,
+    dragHandle: undefined,
+    parentId: undefined,
+    sourcePosition: undefined,
+    targetPosition: undefined,
+  } as unknown as NodeProps<Node<NodeData>>
+  return render(
+    <ReactFlowProvider>
+      <GroupNode {...props} />
+    </ReactFlowProvider>
+  )
+}
+
+describe('GroupNode', () => {
+  beforeEach(() => {
+    useCanvasStore.setState({ nodes: [], hideIp: false })
+    useThemeStore.setState({ activeTheme: 'default' })
+  })
+
+  it('renders label', () => {
+    const { getByText } = renderNode({ label: 'My Group' })
+    expect(getByText('My Group')).toBeDefined()
+  })
+
+  it('renders 4 source handles (one per side)', () => {
+    const { container } = renderNode()
+    expect(container.querySelector('.react-flow__handle-top.source')).not.toBeNull()
+    expect(container.querySelector('.react-flow__handle-right.source')).not.toBeNull()
+    expect(container.querySelector('.react-flow__handle-bottom.source')).not.toBeNull()
+    expect(container.querySelector('.react-flow__handle-left.source')).not.toBeNull()
+  })
+
+  it('renders 4 target handles (one per side)', () => {
+    const { container } = renderNode()
+    expect(container.querySelector('.react-flow__handle-top.target')).not.toBeNull()
+    expect(container.querySelector('.react-flow__handle-right.target')).not.toBeNull()
+    expect(container.querySelector('.react-flow__handle-bottom.target')).not.toBeNull()
+    expect(container.querySelector('.react-flow__handle-left.target')).not.toBeNull()
+  })
+
+  it('source handles carry side-specific ids', () => {
+    const { container } = renderNode()
+    expect(container.querySelector('[data-handleid="group-top"]')).not.toBeNull()
+    expect(container.querySelector('[data-handleid="group-right"]')).not.toBeNull()
+    expect(container.querySelector('[data-handleid="group-bottom"]')).not.toBeNull()
+    expect(container.querySelector('[data-handleid="group-left"]')).not.toBeNull()
+  })
+})

--- a/frontend-src/src/components/modals/NodeModal.tsx
+++ b/frontend-src/src/components/modals/NodeModal.tsx
@@ -11,6 +11,7 @@ import { resolveNodeColors } from '@/utils/nodeColors'
 import { ICON_REGISTRY, ICON_CATEGORIES, NODE_TYPE_DEFAULT_ICONS, isBrandIconKey, brandIconSlug, brandIconUrl } from '@/utils/nodeIcons'
 import { BrandIconPicker } from './BrandIconPicker'
 import { MIN_BOTTOM_HANDLES, MAX_BOTTOM_HANDLES, clampBottomHandles } from '@/utils/handleUtils'
+import { getValidParentTypes } from '@/utils/virtualEdgeParent'
 
 const NODE_TYPE_GROUPS: { label: string; types: NodeType[] }[] = [
   { label: 'Hardware',       types: ['isp', 'router', 'firewall', 'switch', 'server', 'nas', 'ap', 'printer'] },
@@ -61,18 +62,25 @@ const DEFAULT_DATA: Partial<NodeData> = {
   custom_icon: undefined,
 }
 
+interface ParentCandidate {
+  id: string
+  label: string
+  type: NodeType
+}
+
 interface NodeModalProps {
   open: boolean
   onClose: () => void
   onSubmit: (data: Partial<NodeData>) => void
   initial?: Partial<NodeData>
   title?: string
-  parentContainerNodes?: { id: string; label: string; nodeType?: NodeType }[]
+  parentCandidates?: ParentCandidate[]
+  currentNodeId?: string
 }
 
 // NodeModal is always mounted with a key that changes on open/edit, so useState
 // initial value is enough - no need for a reset effect.
-export function NodeModal({ open, onClose, onSubmit, initial, title = 'Add Node', parentContainerNodes = [] }: NodeModalProps) {
+export function NodeModal({ open, onClose, onSubmit, initial, title = 'Add Node', parentCandidates = [], currentNodeId }: NodeModalProps) {
   const [form, setForm] = useState<Partial<NodeData>>({ ...DEFAULT_DATA, ...initial })
   const [iconSearch, setIconSearch] = useState('')
   const [iconPickerOpen, setIconPickerOpen] = useState(false)
@@ -92,18 +100,23 @@ export function NodeModal({ open, onClose, onSubmit, initial, title = 'Add Node'
     const selectedType = (form.type ?? 'generic') as NodeType
     const canUseContainerMode = CONTAINER_MODE_TYPES.includes(selectedType)
     const isZigbee = selectedType.startsWith('zigbee_')
+    const validParentTypes = getValidParentTypes(selectedType)
+    let safeParentId = form.parent_id
+    if (validParentTypes.length === 0) {
+      safeParentId = undefined
+    } else if (safeParentId) {
+      const parent = parentCandidates.find((n) => n.id === safeParentId)
+      if (!parent || !validParentTypes.includes(parent.type)) safeParentId = undefined
+    }
     onSubmit({
       ...form,
       check_method: isZigbee ? 'none' : form.check_method,
       check_target: isZigbee ? undefined : form.check_target,
+      parent_id: safeParentId,
       container_mode: canUseContainerMode ? !!form.container_mode : false,
     })
     onClose()
   }
-
-  const filteredParentNodes = form.type === 'docker_container'
-    ? parentContainerNodes.filter((n) => n.nodeType === 'docker_host')
-    : parentContainerNodes
 
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
@@ -117,7 +130,14 @@ export function NodeModal({ open, onClose, onSubmit, initial, title = 'Add Node'
             {/* Type + Icon on the same row */}
             <div className="flex flex-col gap-1.5">
               <Label className="text-xs text-muted-foreground">Type</Label>
-              <Select value={form.type} onValueChange={(v) => set('type', v as NodeType)}>
+              <Select value={form.type} onValueChange={(v) => {
+                const t = v as NodeType
+                setForm((f) => {
+                  const next: Partial<NodeData> = { ...f, type: t }
+                  if (getValidParentTypes(t).length === 0) next.parent_id = undefined
+                  return next
+                })
+              }}>
                 <SelectTrigger className={`bg-[#21262d] border-[#30363d] text-sm h-8 w-full cursor-pointer ${modalStyles['modal-interactive']} ${modalStyles['modal-radius']}`} aria-label="Node type selector">
                   <SelectValue>{NODE_TYPE_LABELS[(form.type ?? 'server') as NodeType]}</SelectValue>
                 </SelectTrigger>
@@ -328,30 +348,39 @@ export function NodeModal({ open, onClose, onSubmit, initial, title = 'Add Node'
               </>
             )}
 
-            {/* Parent container */}
-            {form.type !== 'groupRect' && form.type !== 'group' && filteredParentNodes.length > 0 && (
-              <div className="flex flex-col gap-1.5 col-span-2">
-                <Label className="text-xs text-muted-foreground">Parent Container</Label>
-                <Select
-                  value={form.parent_id ?? 'none'}
-                  onValueChange={(v) => set('parent_id', v === 'none' ? undefined : v)}
-                >
-                  <SelectTrigger className={`bg-[#21262d] border-[#30363d] text-sm h-8 cursor-pointer ${modalStyles['modal-interactive']} ${modalStyles['modal-radius']}`} aria-label="Parent container selector">
-                    <SelectValue placeholder="None (standalone)">
-                      {form.parent_id
-                        ? (filteredParentNodes.find((n) => n.id === form.parent_id)?.label ?? 'None (standalone)')
-                        : 'None (standalone)'}
-                    </SelectValue>
-                  </SelectTrigger>
-                  <SelectContent className="bg-[#21262d] border-[#30363d]">
-                    <SelectItem value="none" className="text-sm">None (standalone)</SelectItem>
-                    {filteredParentNodes.map((n) => (
-                      <SelectItem key={n.id} value={n.id} className="text-sm">{n.label}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            )}
+            {/* Parent Container */}
+            {(() => {
+              const childType = (form.type ?? 'generic') as NodeType
+              const validParentTypes = getValidParentTypes(childType)
+              if (validParentTypes.length === 0) return null
+              const validParents = parentCandidates.filter(
+                (n) => n.id !== currentNodeId && validParentTypes.includes(n.type),
+              )
+              if (validParents.length === 0) return null
+              return (
+                <div className="flex flex-col gap-1.5 col-span-2">
+                  <Label className="text-xs text-muted-foreground">Parent Container</Label>
+                  <Select
+                    value={form.parent_id ?? 'none'}
+                    onValueChange={(v) => set('parent_id', v === 'none' ? undefined : v)}
+                  >
+                    <SelectTrigger className={`bg-[#21262d] border-[#30363d] text-sm h-8 cursor-pointer ${modalStyles['modal-interactive']} ${modalStyles['modal-radius']}`} aria-label="Parent container selector">
+                      <SelectValue>
+                        {form.parent_id
+                          ? (validParents.find((n) => n.id === form.parent_id)?.label ?? 'None')
+                          : 'None'}
+                      </SelectValue>
+                    </SelectTrigger>
+                    <SelectContent className="bg-[#21262d] border-[#30363d]">
+                      <SelectItem value="none" className="text-sm">None</SelectItem>
+                      {validParents.map((n) => (
+                        <SelectItem key={n.id} value={n.id} className="text-sm">{n.label}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              )
+            })()}
 
             {/* Container mode */}
             {CONTAINER_MODE_TYPES.includes((form.type ?? 'generic') as NodeType) && (

--- a/frontend-src/src/components/modals/__tests__/NodeModal.test.tsx
+++ b/frontend-src/src/components/modals/__tests__/NodeModal.test.tsx
@@ -288,46 +288,52 @@ describe('NodeModal', () => {
     expect((onSubmit.mock.calls[0][0] as Partial<NodeData>).container_mode).toBe(false)
   })
 
-  // ── Parent container ──────────────────────────────────────────────────
+  // ── Parent Container selector ─────────────────────────────────────────
 
-  const parentContainerVisibleTypes = ['proxmox', 'vm', 'lxc', 'docker_host', 'isp', 'router', 'switch', 'server', 'nas', 'ap', 'printer', 'iot', 'camera', 'cpl', 'computer', 'generic'] as const
-  const parentContainerHiddenTypes = ['groupRect', 'group'] as const
-
-  it.each(parentContainerVisibleTypes)('shows Parent Container for %s type when options are provided', (type) => {
+  it('does not render Parent Container for non-child types', () => {
     renderModal({
-      initial: { ...BASE, type },
-      parentContainerNodes: [{ id: 'c1', label: 'Container 01' }],
+      initial: BASE,
+      parentCandidates: [{ id: 'p1', label: 'Proxmox', type: 'proxmox' }],
+    })
+    expect(screen.queryByText('Parent Container')).toBeNull()
+  })
+
+  it('does not render Parent Container when no valid candidates exist', () => {
+    renderModal({
+      initial: { ...BASE, type: 'docker_container' },
+      parentCandidates: [],
+    })
+    expect(screen.queryByText('Parent Container')).toBeNull()
+  })
+
+  it('renders Parent Container for docker_container when docker_host candidate exists', () => {
+    renderModal({
+      initial: { ...BASE, type: 'docker_container' },
+      parentCandidates: [{ id: 'dh1', label: 'Docker Host', type: 'docker_host' }],
     })
     expect(screen.getByText('Parent Container')).toBeDefined()
-    expect(screen.getByText('Container 01')).toBeDefined()
   })
 
-  it.each(parentContainerHiddenTypes)('hides Parent Container for %s type even when options are provided', (type) => {
-    renderModal({ initial: { ...BASE, type }, parentContainerNodes: [{ id: 'c1', label: 'Container 01' }] })
-    expect(screen.queryByText('Parent Container')).toBeNull()
-  })
-
-  it.each(parentContainerVisibleTypes)('hides Parent Container for %s type when no container options are available', (type) => {
-    renderModal({ initial: { ...BASE, type } })
-    expect(screen.queryByText('Parent Container')).toBeNull()
-  })
-
-  it('docker_container shows only docker_host parents', () => {
+  it('renders Parent Container for docker_container when only an LXC candidate exists', () => {
     renderModal({
       initial: { ...BASE, type: 'docker_container' },
-      parentContainerNodes: [
-        { id: 'h1', label: 'My Docker Host', nodeType: 'docker_host' },
-        { id: 'p1', label: 'My Proxmox', nodeType: 'proxmox' },
-      ],
+      parentCandidates: [{ id: 'lxc1', label: 'My LXC', type: 'lxc' }],
     })
-    expect(screen.getByText('My Docker Host')).toBeDefined()
-    expect(screen.queryByText('My Proxmox')).toBeNull()
+    expect(screen.getByText('Parent Container')).toBeDefined()
   })
 
-  it('docker_container hides Parent Container when no docker_host is available', () => {
+  it('renders Parent Container for lxc when proxmox candidate exists', () => {
+    renderModal({
+      initial: { ...BASE, type: 'lxc' },
+      parentCandidates: [{ id: 'px1', label: 'PVE', type: 'proxmox' }],
+    })
+    expect(screen.getByText('Parent Container')).toBeDefined()
+  })
+
+  it('excludes unsupported candidate types for docker_container', () => {
     renderModal({
       initial: { ...BASE, type: 'docker_container' },
-      parentContainerNodes: [{ id: 'p1', label: 'My Proxmox', nodeType: 'proxmox' }],
+      parentCandidates: [{ id: 'srv1', label: 'Plain Server', type: 'server' }],
     })
     expect(screen.queryByText('Parent Container')).toBeNull()
   })

--- a/frontend-src/src/utils/__tests__/containerEdgeSync.test.ts
+++ b/frontend-src/src/utils/__tests__/containerEdgeSync.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { planContainerModeEdgeSync, type VirtualEdgeRef } from '../containerEdgeSync'
+
+describe('planContainerModeEdgeSync', () => {
+  it('adds an edge for each child with no existing virtual edge when turning OFF', () => {
+    const plan = planContainerModeEdgeSync('px1', false, ['c1', 'c2'], [])
+    expect(plan).toEqual({ addChildIds: ['c1', 'c2'], removeEdgeIds: [] })
+  })
+
+  it('does not duplicate an edge that already exists when turning OFF', () => {
+    const edges: VirtualEdgeRef[] = [{ id: 'e1', source: 'c1', target: 'px1' }]
+    const plan = planContainerModeEdgeSync('px1', false, ['c1', 'c2'], edges)
+    expect(plan).toEqual({ addChildIds: ['c2'], removeEdgeIds: [] })
+  })
+
+  it('matches an existing edge regardless of source/target direction', () => {
+    const edges: VirtualEdgeRef[] = [{ id: 'e1', source: 'px1', target: 'c1' }]
+    const plan = planContainerModeEdgeSync('px1', false, ['c1'], edges)
+    expect(plan).toEqual({ addChildIds: [], removeEdgeIds: [] })
+  })
+
+  it('removes existing virtual edges for children when turning ON', () => {
+    const edges: VirtualEdgeRef[] = [
+      { id: 'e1', source: 'c1', target: 'px1' },
+      { id: 'e2', source: 'px1', target: 'c2' },
+    ]
+    const plan = planContainerModeEdgeSync('px1', true, ['c1', 'c2'], edges)
+    expect(plan).toEqual({ addChildIds: [], removeEdgeIds: ['e1', 'e2'] })
+  })
+
+  it('removes nothing when turning ON and no edges exist', () => {
+    const plan = planContainerModeEdgeSync('px1', true, ['c1'], [])
+    expect(plan).toEqual({ addChildIds: [], removeEdgeIds: [] })
+  })
+
+  it('ignores virtual edges unrelated to the container or its children', () => {
+    const edges: VirtualEdgeRef[] = [{ id: 'e9', source: 'a', target: 'b' }]
+    const plan = planContainerModeEdgeSync('px1', false, ['c1'], edges)
+    expect(plan).toEqual({ addChildIds: ['c1'], removeEdgeIds: [] })
+  })
+
+  it('returns empty plan when the container has no children', () => {
+    const plan = planContainerModeEdgeSync('px1', false, [], [])
+    expect(plan).toEqual({ addChildIds: [], removeEdgeIds: [] })
+  })
+})

--- a/frontend-src/src/utils/__tests__/virtualEdgeParent.test.ts
+++ b/frontend-src/src/utils/__tests__/virtualEdgeParent.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { resolveVirtualEdgeParent } from '../virtualEdgeParent'
+
+describe('resolveVirtualEdgeParent', () => {
+  it('nests lxc under proxmox (container-mode parent)', () => {
+    const res = resolveVirtualEdgeParent(
+      { id: 'lxc1', type: 'lxc' },
+      { id: 'px1', type: 'proxmox' },
+    )
+    expect(res).toEqual({ childId: 'lxc1', parentId: 'px1' })
+  })
+
+  it('nests vm under proxmox regardless of edge direction', () => {
+    const res = resolveVirtualEdgeParent(
+      { id: 'px1', type: 'proxmox' },
+      { id: 'vm1', type: 'vm' },
+    )
+    expect(res).toEqual({ childId: 'vm1', parentId: 'px1' })
+  })
+
+  it('nests docker_container under docker_host', () => {
+    const res = resolveVirtualEdgeParent(
+      { id: 'dc1', type: 'docker_container' },
+      { id: 'dh1', type: 'docker_host' },
+    )
+    expect(res).toEqual({ childId: 'dc1', parentId: 'dh1' })
+  })
+
+  it('nests docker_container under lxc (reverse direction)', () => {
+    const res = resolveVirtualEdgeParent(
+      { id: 'lxc1', type: 'lxc' },
+      { id: 'dc1', type: 'docker_container' },
+    )
+    expect(res).toEqual({ childId: 'dc1', parentId: 'lxc1' })
+  })
+
+  it('nests docker_container under lxc (forward direction)', () => {
+    const res = resolveVirtualEdgeParent(
+      { id: 'dc1', type: 'docker_container' },
+      { id: 'lxc1', type: 'lxc' },
+    )
+    expect(res).toEqual({ childId: 'dc1', parentId: 'lxc1' })
+  })
+
+  it('nests docker_container under vm', () => {
+    const res = resolveVirtualEdgeParent(
+      { id: 'dc1', type: 'docker_container' },
+      { id: 'vm1', type: 'vm' },
+    )
+    expect(res).toEqual({ childId: 'dc1', parentId: 'vm1' })
+  })
+
+  it('nests docker_container under proxmox (reverse direction)', () => {
+    const res = resolveVirtualEdgeParent(
+      { id: 'px1', type: 'proxmox' },
+      { id: 'dc1', type: 'docker_container' },
+    )
+    expect(res).toEqual({ childId: 'dc1', parentId: 'px1' })
+  })
+
+  it('returns null when docker_container links to unsupported parent type', () => {
+    const res = resolveVirtualEdgeParent(
+      { id: 'dc1', type: 'docker_container' },
+      { id: 'srv1', type: 'server' },
+    )
+    expect(res).toBeNull()
+  })
+
+  it('returns null for unrelated type pairs', () => {
+    const res = resolveVirtualEdgeParent(
+      { id: 'srv1', type: 'server' },
+      { id: 'rt1', type: 'router' },
+    )
+    expect(res).toBeNull()
+  })
+})

--- a/frontend-src/src/utils/__tests__/virtualEdgeParent.test.ts
+++ b/frontend-src/src/utils/__tests__/virtualEdgeParent.test.ts
@@ -1,5 +1,26 @@
 import { describe, it, expect } from 'vitest'
-import { resolveVirtualEdgeParent } from '../virtualEdgeParent'
+import { resolveVirtualEdgeParent, getValidParentTypes } from '../virtualEdgeParent'
+
+describe('getValidParentTypes', () => {
+  it('returns container-mode types for lxc', () => {
+    expect(getValidParentTypes('lxc')).toEqual(['proxmox', 'vm', 'lxc', 'docker_host'])
+  })
+
+  it('returns container-mode types for vm', () => {
+    expect(getValidParentTypes('vm')).toEqual(['proxmox', 'vm', 'lxc', 'docker_host'])
+  })
+
+  it('returns docker_host/lxc/vm/proxmox for docker_container', () => {
+    expect(getValidParentTypes('docker_container')).toEqual(['docker_host', 'lxc', 'vm', 'proxmox'])
+  })
+
+  it('returns empty list for types that cannot have a parent', () => {
+    expect(getValidParentTypes('server')).toEqual([])
+    expect(getValidParentTypes('router')).toEqual([])
+    expect(getValidParentTypes('proxmox')).toEqual([])
+    expect(getValidParentTypes('docker_host')).toEqual([])
+  })
+})
 
 describe('resolveVirtualEdgeParent', () => {
   it('nests lxc under proxmox (container-mode parent)', () => {

--- a/frontend-src/src/utils/containerEdgeSync.ts
+++ b/frontend-src/src/utils/containerEdgeSync.ts
@@ -1,0 +1,43 @@
+// When a container node toggles container_mode, its domain children
+// (nodes whose data.parent_id points at it) need their relationship re-expressed:
+//   - container_mode ON  → containment is shown visually (nested), drop the edge
+//   - container_mode OFF → node is no longer nested, draw a virtual edge instead
+//
+// Pure planner: returns which children need a new virtual edge and which existing
+// virtual edges should be removed. The caller performs the actual mutations.
+
+export interface VirtualEdgeRef {
+  id: string
+  source: string
+  target: string
+}
+
+export interface ContainerEdgeSyncPlan {
+  addChildIds: string[]
+  removeEdgeIds: string[]
+}
+
+export function planContainerModeEdgeSync(
+  containerId: string,
+  enabled: boolean,
+  childIds: string[],
+  virtualEdges: VirtualEdgeRef[],
+): ContainerEdgeSyncPlan {
+  const addChildIds: string[] = []
+  const removeEdgeIds: string[] = []
+
+  for (const childId of childIds) {
+    const existing = virtualEdges.find(
+      (e) =>
+        (e.source === childId && e.target === containerId) ||
+        (e.source === containerId && e.target === childId),
+    )
+    if (enabled) {
+      if (existing) removeEdgeIds.push(existing.id)
+    } else if (!existing) {
+      addChildIds.push(childId)
+    }
+  }
+
+  return { addChildIds, removeEdgeIds }
+}

--- a/frontend-src/src/utils/virtualEdgeParent.ts
+++ b/frontend-src/src/utils/virtualEdgeParent.ts
@@ -1,0 +1,38 @@
+import type { NodeData } from '@/types'
+
+export type NodeType = NodeData['type']
+
+const CONTAINER_MODE_TYPES = new Set<NodeType>(['proxmox', 'vm', 'lxc', 'docker_host'])
+const DOCKER_CONTAINER_PARENT_TYPES = new Set<NodeType>(['docker_host', 'lxc', 'vm', 'proxmox'])
+
+export interface VirtualEdgeEndpoint {
+  id: string
+  type: NodeType
+}
+
+export interface ParentAssignment {
+  childId: string
+  parentId: string
+}
+
+export function resolveVirtualEdgeParent(
+  source: VirtualEdgeEndpoint,
+  target: VirtualEdgeEndpoint,
+): ParentAssignment | null {
+  const { type: srcType, id: srcId } = source
+  const { type: tgtType, id: tgtId } = target
+
+  if ((srcType === 'lxc' || srcType === 'vm') && CONTAINER_MODE_TYPES.has(tgtType)) {
+    return { childId: srcId, parentId: tgtId }
+  }
+  if (CONTAINER_MODE_TYPES.has(srcType) && (tgtType === 'lxc' || tgtType === 'vm')) {
+    return { childId: tgtId, parentId: srcId }
+  }
+  if (srcType === 'docker_container' && DOCKER_CONTAINER_PARENT_TYPES.has(tgtType)) {
+    return { childId: srcId, parentId: tgtId }
+  }
+  if (tgtType === 'docker_container' && DOCKER_CONTAINER_PARENT_TYPES.has(srcType)) {
+    return { childId: tgtId, parentId: srcId }
+  }
+  return null
+}

--- a/frontend-src/src/utils/virtualEdgeParent.ts
+++ b/frontend-src/src/utils/virtualEdgeParent.ts
@@ -15,6 +15,16 @@ export interface ParentAssignment {
   parentId: string
 }
 
+export function getValidParentTypes(childType: NodeType): NodeType[] {
+  if (childType === 'lxc' || childType === 'vm') {
+    return ['proxmox', 'vm', 'lxc', 'docker_host']
+  }
+  if (childType === 'docker_container') {
+    return ['docker_host', 'lxc', 'vm', 'proxmox']
+  }
+  return []
+}
+
 export function resolveVirtualEdgeParent(
   source: VirtualEdgeEndpoint,
   target: VirtualEdgeEndpoint,


### PR DESCRIPTION
Ports three changes from the standalone `homelable` repo.

## homelable#152 — Group node 4 side handles
- GroupNode acts as edge source/target from any side (4 snap handles + invisible target overlays, theme-colored).

## homelable#153 — LXC as parent for docker_container (virtual edge)
- Drawing a virtual edge nests `docker_container` under `lxc`/`vm`/`proxmox`, not just `docker_host`.
- Logic extracted into pure helper `resolveVirtualEdgeParent`.

## homelable selector commit `3a4df57` + #154 — Parent Container selector
- Fixes the actual UX gap: the NodeModal **Parent Container** dropdown now offers lxc/vm/proxmox for a `docker_container` (was hard-filtered to `docker_host`).
- Allowlist centralized in `getValidParentTypes`, shared with the edge helper.
- `parent_id` sanitized on submit and cleared on type change; edited node's descendants excluded from candidates (cycle guard).

### HACS adaptation
- Standalone's NodeModal had diverged (old selector removed then re-added). Ported the end-state selector model (`parentCandidates`/`currentNodeId`) onto the hacs NodeModal, replacing the old `parentContainerNodes`/`filteredParentNodes` path. `CONTAINER_MODE_TYPES` const in `App.tsx` is now unused and removed.

## Tests
- 839 passed (group handles, virtual-edge helper, getValidParentTypes, NodeModal selector).
- typecheck clean, lint 0 errors, `build:ha` OK.