### PR TITLE
feat(scan): carry scanned MAC onto approved nodes

### DIFF
--- a/custom_components/homelable/coordinator.py
+++ b/custom_components/homelable/coordinator.py
@@ -43,6 +43,34 @@ _EMPTY_CANVAS = {"nodes": [], "edges": [], "viewport": {"x": 0, "y": 0, "zoom": 
 _EMPTY_PENDING: dict[str, Any] = {"devices": []}
 
 
+def build_mac_property(mac: str | None) -> list[dict[str, Any]]:
+    """Build a NodeProperty list carrying a device MAC address.
+
+    Shape matches the frontend ``NodeProperty`` type
+    (``{key, value, icon, visible}``). Hidden by default — the user opts in to
+    showing it on the canvas card from the right panel. Returns an empty list
+    when no MAC is known.
+    """
+    if not mac:
+        return []
+    return [{"key": "MAC", "value": mac, "icon": None, "visible": False}]
+
+
+def merge_mac_property(
+    props: list[dict[str, Any]] | None, mac: str | None
+) -> list[dict[str, Any]]:
+    """Append a MAC NodeProperty to ``props`` unless one is already present.
+
+    Preserves any user-supplied properties (and an existing MAC row's
+    visibility) untouched. Used on approve so the scanned MAC is not lost.
+    """
+    out = [dict(p) for p in (props or [])]
+    if not mac or any(p.get("key") == "MAC" for p in out):
+        return out
+    out.append({"key": "MAC", "value": mac, "icon": None, "visible": False})
+    return out
+
+
 def _utc_now_iso() -> str:
     """ISO-8601 UTC with trailing 'Z' (frontend Date() expects this form)."""
     return datetime.now(UTC).isoformat().replace("+00:00", "Z")
@@ -510,6 +538,13 @@ class HomelableCoordinator(DataUpdateCoordinator):
             **data_extras,
             **overrides.get("data", {}),
         }
+        # Non-zigbee nodes carry the scanned MAC as a hidden property row so the
+        # user can opt in to showing it on the canvas card. Merge (rather than
+        # overwrite) to preserve any properties carried on the approve payload.
+        if not is_zigbee:
+            node["properties"] = merge_mac_property(
+                node.get("properties"), device.get("mac")
+            )
 
         canvas = await self.get_canvas(design_id)
         canvas.setdefault("nodes", []).append(node)

--- a/frontend-src/src/components/modals/PendingDevicesModal.tsx
+++ b/frontend-src/src/components/modals/PendingDevicesModal.tsx
@@ -11,6 +11,7 @@ import { toast } from 'sonner'
 import { PendingDeviceModal, type PendingDevice } from '@/components/modals/PendingDeviceModal'
 import type { NodeType, ServiceInfo } from '@/types'
 import { buildZigbeeProperties, isZigbeeType } from '@/utils/zigbeeProperties'
+import { buildMacProperty } from '@/utils/macProperty'
 
 interface PendingDevicesModalProps {
   open: boolean
@@ -250,10 +251,11 @@ export function PendingDevicesModal({ open, onClose, highlightId, initialStatus 
         label: fallbackLabel,
         type,
         ip: device.ip ?? undefined,
+        mac: device.mac ?? undefined,
         hostname: device.hostname ?? undefined,
         status: zigbee ? 'online' : 'unknown',
         services: (device.services ?? []) as ServiceInfo[],
-        properties: zigbee ? buildZigbeeProperties(device) : [],
+        properties: zigbee ? buildZigbeeProperties(device) : buildMacProperty(device.mac),
       }
       const res = await scanApi.approve(device.id, nodeData, activeDesignId)
       const nodeId = res.data.node_id
@@ -315,10 +317,11 @@ export function PendingDevicesModal({ open, onClose, highlightId, initialStatus 
             label: deviceLabel(d),
             type,
             ip: d.ip ?? undefined,
+            mac: d.mac ?? undefined,
             hostname: d.hostname ?? undefined,
             status: zigbee ? ('online' as const) : ('unknown' as const),
             services: (d.services ?? []) as ServiceInfo[],
-            properties: zigbee ? buildZigbeeProperties(d) : [],
+            properties: zigbee ? buildZigbeeProperties(d) : buildMacProperty(d.mac),
           },
         })
       })

--- a/frontend-src/src/utils/__tests__/macProperty.test.ts
+++ b/frontend-src/src/utils/__tests__/macProperty.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { buildMacProperty } from '../macProperty'
+
+describe('buildMacProperty', () => {
+  it('returns a hidden MAC property row for a MAC', () => {
+    expect(buildMacProperty('aa:bb:cc:dd:ee:ff')).toEqual([
+      { key: 'MAC', value: 'aa:bb:cc:dd:ee:ff', icon: null, visible: false },
+    ])
+  })
+
+  it('returns an empty array when MAC is null/undefined/empty', () => {
+    expect(buildMacProperty(null)).toEqual([])
+    expect(buildMacProperty(undefined)).toEqual([])
+    expect(buildMacProperty('')).toEqual([])
+  })
+})

--- a/frontend-src/src/utils/macProperty.ts
+++ b/frontend-src/src/utils/macProperty.ts
@@ -1,0 +1,9 @@
+import type { NodeProperty } from '@/types'
+
+/** Build the MAC address property row shown in the right panel.
+ * Hidden by default — the user opts in to showing it on the canvas card.
+ * Matches backend `build_mac_property`. Returns an empty array when no MAC. */
+export function buildMacProperty(mac?: string | null): NodeProperty[] {
+  if (!mac) return []
+  return [{ key: 'MAC', value: mac, icon: null, visible: false }]
+}

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3,7 +3,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from custom_components.homelable.coordinator import HomelableCoordinator
+from custom_components.homelable.coordinator import (
+    HomelableCoordinator,
+    build_mac_property,
+    merge_mac_property,
+)
 
 
 def _mock_entry(scan_ranges: str = "192.168.1.0/24") -> MagicMock:
@@ -408,6 +412,59 @@ async def test_approve_non_zigbee_has_empty_properties(coord) -> None:  # noqa: 
     assert node["properties"] == []
     assert node["status"] == "unknown"
     assert node["check_method"] == "ping"
+
+
+# --- MAC address propagation on approve (issue #168) ---
+
+def test_build_mac_property_returns_hidden_row() -> None:
+    assert build_mac_property("aa:bb:cc:dd:ee:ff") == [
+        {"key": "MAC", "value": "aa:bb:cc:dd:ee:ff", "icon": None, "visible": False}
+    ]
+
+
+def test_build_mac_property_empty_when_no_mac() -> None:
+    assert build_mac_property(None) == []
+    assert build_mac_property("") == []
+
+
+def test_merge_mac_property_appends_when_absent() -> None:
+    existing = [{"key": "Note", "value": "x", "icon": None, "visible": True}]
+    merged = merge_mac_property(existing, "aa:bb:cc:dd:ee:ff")
+    assert merged == [
+        {"key": "Note", "value": "x", "icon": None, "visible": True},
+        {"key": "MAC", "value": "aa:bb:cc:dd:ee:ff", "icon": None, "visible": False},
+    ]
+    # Source list left untouched.
+    assert existing == [{"key": "Note", "value": "x", "icon": None, "visible": True}]
+
+
+def test_merge_mac_property_keeps_existing_mac_row() -> None:
+    existing = [{"key": "MAC", "value": "old", "icon": None, "visible": True}]
+    assert merge_mac_property(existing, "aa:bb:cc:dd:ee:ff") == existing
+
+
+@pytest.mark.asyncio
+async def test_approve_non_zigbee_carries_scanned_mac(coord) -> None:  # noqa: ANN001
+    """A non-zigbee device with a scanned MAC lands a hidden MAC property row."""
+    pending = await coord._get_pending()
+    pending["devices"].append(
+        {
+            "id": "pd-mac",
+            "ip": "192.168.1.6",
+            "mac": "aa:bb:cc:dd:ee:ff",
+            "hostname": "printer",
+            "os": None,
+            "services": [],
+            "suggested_type": "generic",
+            "status": "pending",
+        }
+    )
+    await coord._save_pending()
+    node = await coord.approve_pending("pd-mac")
+    assert node["mac"] == "aa:bb:cc:dd:ee:ff"
+    assert node["properties"] == [
+        {"key": "MAC", "value": "aa:bb:cc:dd:ee:ff", "icon": None, "visible": False}
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Port of standalone [PR #178](https://github.com/Pouzor/homelable/pull/178) (issue #168).

Approving a discovered **non-zigbee** device now attaches its scanned MAC as a hidden `NodeProperty` row, so users can opt in to showing it on the canvas card from the right panel.

## hacs adaptation
Standalone uses a FastAPI route + `Node` ORM. Here both the single and batch approve WS paths funnel through `coordinator.approve_pending`, so the merge happens in one place. The node `mac` field was already populated; the missing piece was the property row.

## Changes
- **coordinator**: add `build_mac_property` / `merge_mac_property`; `approve_pending` merges the scanned MAC into non-zigbee node properties (preserves any payload-supplied props, no duplicate MAC row).
- **frontend**: add `buildMacProperty` util; `PendingDevicesModal` single + bulk approve now send `mac` and build the MAC property instead of `[]`.
- **tests**: coordinator helper + approve-with-MAC cases; `macProperty` vitest.

## Verification
- `ruff` ✓
- `pytest` 144 passed ✓
- `tsc --noEmit` ✓ / vitest `macProperty` ✓

Existing `test_approve_non_zigbee_has_empty_properties` stays green (its device has `mac=None`).