### PR TITLE
feat: per-service status checks + ping/IPv6/service-color fixes

### DIFF
--- a/custom_components/homelable/__init__.py
+++ b/custom_components/homelable/__init__.py
@@ -36,6 +36,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if PLATFORMS:
         await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    # Optional independent per-service status checks (off by default). Reload on
+    # options change recreates the coordinator, so the timer always reflects the
+    # latest setting.
+    coordinator.async_start_service_checks()
+    entry.async_on_unload(coordinator.async_stop_service_checks)
+
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
     return True
 

--- a/custom_components/homelable/config_flow.py
+++ b/custom_components/homelable/config_flow.py
@@ -10,13 +10,18 @@ from homeassistant.core import callback
 from .const import (
     CONF_SCAN_INTERVAL,
     CONF_SCAN_RANGES,
+    CONF_SERVICE_CHECK_ENABLED,
+    CONF_SERVICE_CHECK_INTERVAL,
     CONF_STATUS_INTERVAL,
     CONF_ZIGBEE_BASE_TOPIC,
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_SCAN_RANGES,
+    DEFAULT_SERVICE_CHECK_ENABLED,
+    DEFAULT_SERVICE_CHECK_INTERVAL,
     DEFAULT_STATUS_INTERVAL,
     DEFAULT_ZIGBEE_BASE_TOPIC,
     DOMAIN,
+    MIN_SERVICE_CHECK_INTERVAL,
 )
 
 
@@ -97,6 +102,18 @@ class HomelableOptionsFlow(OptionsFlow):
                         CONF_ZIGBEE_BASE_TOPIC, DEFAULT_ZIGBEE_BASE_TOPIC
                     ),
                 ): str,
+                vol.Required(
+                    CONF_SERVICE_CHECK_ENABLED,
+                    default=data.get(
+                        CONF_SERVICE_CHECK_ENABLED, DEFAULT_SERVICE_CHECK_ENABLED
+                    ),
+                ): bool,
+                vol.Required(
+                    CONF_SERVICE_CHECK_INTERVAL,
+                    default=data.get(
+                        CONF_SERVICE_CHECK_INTERVAL, DEFAULT_SERVICE_CHECK_INTERVAL
+                    ),
+                ): vol.All(int, vol.Range(min=MIN_SERVICE_CHECK_INTERVAL)),
             }
         )
         return self.async_show_form(step_id="init", data_schema=schema)

--- a/custom_components/homelable/const.py
+++ b/custom_components/homelable/const.py
@@ -28,11 +28,17 @@ CONF_SCAN_RANGES = "scan_ranges"
 CONF_SCAN_INTERVAL = "scan_interval"
 CONF_STATUS_INTERVAL = "status_interval"
 CONF_ZIGBEE_BASE_TOPIC = "zigbee_base_topic"
+CONF_SERVICE_CHECK_ENABLED = "service_check_enabled"
+CONF_SERVICE_CHECK_INTERVAL = "service_check_interval"
 
 DEFAULT_SCAN_RANGES = ["192.168.1.0/24"]
 DEFAULT_SCAN_INTERVAL = 3600  # seconds (1h)
 DEFAULT_STATUS_INTERVAL = 60   # seconds
 DEFAULT_ZIGBEE_BASE_TOPIC = "zigbee2mqtt"
+# Per-service status checks are independent of node checks and off by default.
+DEFAULT_SERVICE_CHECK_ENABLED = False
+DEFAULT_SERVICE_CHECK_INTERVAL = 300  # seconds (5 min)
+MIN_SERVICE_CHECK_INTERVAL = 30   # seconds
 
 # Zigbee networkmap timeouts (seconds). Large meshes (>50 devices) routinely
 # take 2-4 minutes; coordinator polls every router for routing tables.
@@ -42,6 +48,11 @@ ZIGBEE_NETWORKMAP_TIMEOUT = 300.0
 # / scan_phase / scan_finished / scan_cancelled). Subscribers receive a single
 # dict payload; see websocket.ws_scan_subscribe.
 SCAN_SIGNAL = f"{DOMAIN}_scan_event"
+
+# Dispatcher signal for live per-service status results. Subscribers receive a
+# dict payload {node_id, services: [{port, protocol, status}], checked_at}; see
+# websocket.ws_service_status_subscribe.
+SERVICE_STATUS_SIGNAL = f"{DOMAIN}_service_status"
 
 # Frontend panel
 PANEL_URL = "/homelable_files"

--- a/custom_components/homelable/coordinator.py
+++ b/custom_components/homelable/coordinator.py
@@ -4,29 +4,37 @@ from __future__ import annotations
 import copy
 import logging
 import uuid
+from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from . import scanner, status_checker, zigbee
 from .const import (
     CONF_SCAN_RANGES,
+    CONF_SERVICE_CHECK_ENABLED,
+    CONF_SERVICE_CHECK_INTERVAL,
     CONF_STATUS_INTERVAL,
     CONF_ZIGBEE_BASE_TOPIC,
     DEFAULT_DESIGN_ICON,
     DEFAULT_DESIGN_NAME,
     DEFAULT_DESIGN_TYPE,
     DEFAULT_SCAN_RANGES,
+    DEFAULT_SERVICE_CHECK_ENABLED,
+    DEFAULT_SERVICE_CHECK_INTERVAL,
     DEFAULT_STATUS_INTERVAL,
     DEFAULT_ZIGBEE_BASE_TOPIC,
     DOMAIN,
     MAX_SCAN_RUNS,
+    MIN_SERVICE_CHECK_INTERVAL,
     SCAN_SIGNAL,
+    SERVICE_STATUS_SIGNAL,
     STORAGE_KEY_CANVAS,
     STORAGE_KEY_DESIGNS,
     STORAGE_KEY_PENDING,
@@ -111,6 +119,7 @@ class HomelableCoordinator(DataUpdateCoordinator):
         self._pending: dict[str, Any] | None = None
         self._runs: list[dict[str, Any]] | None = None
         self._scan_run_id: str | None = None
+        self._service_check_unsub: Callable[[], None] | None = None
 
     # ─── Status checks (periodic) ────────────────────────────────────────────
 
@@ -158,6 +167,105 @@ class HomelableCoordinator(DataUpdateCoordinator):
                     "response_time_ms": None,
                 }
         return results
+
+    # ─── Per-service status checks (periodic, independent) ────────────────────
+
+    def get_service_check_enabled(self) -> bool:
+        """Whether per-service checks are enabled (options → data → default)."""
+        return bool(
+            self.entry.options.get(
+                CONF_SERVICE_CHECK_ENABLED,
+                self.entry.data.get(
+                    CONF_SERVICE_CHECK_ENABLED, DEFAULT_SERVICE_CHECK_ENABLED
+                ),
+            )
+        )
+
+    def get_service_check_interval(self) -> int:
+        """Service-check interval in seconds, floored at MIN_SERVICE_CHECK_INTERVAL."""
+        raw = self.entry.options.get(
+            CONF_SERVICE_CHECK_INTERVAL,
+            self.entry.data.get(
+                CONF_SERVICE_CHECK_INTERVAL, DEFAULT_SERVICE_CHECK_INTERVAL
+            ),
+        )
+        try:
+            return max(MIN_SERVICE_CHECK_INTERVAL, int(raw))
+        except (TypeError, ValueError):
+            return DEFAULT_SERVICE_CHECK_INTERVAL
+
+    @callback
+    def async_start_service_checks(self) -> None:
+        """Schedule the periodic service-check job if enabled.
+
+        Returns nothing; the unsub is stored and released by
+        async_stop_service_checks (wired to entry unload in __init__.py).
+        Reload on options change recreates the coordinator, so the interval is
+        always picked up fresh — no live reschedule needed.
+        """
+        if not self.get_service_check_enabled():
+            return
+        interval = timedelta(seconds=self.get_service_check_interval())
+        self._service_check_unsub = async_track_time_interval(
+            self.hass, self._run_service_checks, interval
+        )
+        _LOGGER.debug(
+            "Service checks every %ds", self.get_service_check_interval()
+        )
+
+    @callback
+    def async_stop_service_checks(self) -> None:
+        """Cancel the periodic service-check job, if running."""
+        if self._service_check_unsub is not None:
+            self._service_check_unsub()
+            self._service_check_unsub = None
+
+    async def _run_service_checks(self, _now: datetime | None = None) -> None:
+        """Check every service of every canvas node; dispatch per-node results.
+
+        Mirrors the node-status SSRF policy: hosts that resolve to unsafe
+        addresses outside the configured scan ranges are reported offline.
+        """
+        await self._ensure_loaded()
+        allowed_networks = status_checker._parse_allowed_networks(
+            self.get_scan_ranges()
+        )
+        now = _utc_now_iso()
+        seen: set[str] = set()
+        for node in self._all_canvas_nodes():
+            node_id = node.get("id")
+            if not node_id or node_id in seen:
+                continue
+            seen.add(node_id)
+            data = node.get("data") or {}
+            services = node.get("services") or data.get("services") or []
+            if not services:
+                continue
+            host = self._node_host(
+                node.get("ip") or data.get("ip"),
+                node.get("hostname") or data.get("hostname"),
+            )
+            try:
+                statuses = await status_checker.check_services(
+                    host, services, allowed_networks
+                )
+            except Exception as exc:  # noqa: BLE001
+                _LOGGER.debug("Service checks failed for %s: %s", node_id, exc)
+                continue
+            async_dispatcher_send(
+                self.hass,
+                SERVICE_STATUS_SIGNAL,
+                {"node_id": node_id, "services": statuses, "checked_at": now},
+            )
+
+    @staticmethod
+    def _node_host(ip: str | None, hostname: str | None) -> str | None:
+        """Pick the address to probe services on: first IP, else hostname."""
+        if ip:
+            first = ip.split(",")[0].strip()
+            if first:
+                return first
+        return hostname or None
 
     # ─── Designs (multiple canvases) ─────────────────────────────────────────
 

--- a/custom_components/homelable/status_checker.py
+++ b/custom_components/homelable/status_checker.py
@@ -183,13 +183,41 @@ async def check_node(
         return {"status": "offline", "response_time_ms": None}
 
 
+def _is_ipv6(host: str) -> bool:
+    """True if host is a literal IPv6 address (bracketed or bare)."""
+    try:
+        socket.inet_pton(socket.AF_INET6, host.strip("[]"))
+        return True
+    except OSError:
+        return False
+
+
 async def _ping(host: str) -> bool:
+    # Send 2 probes with a ~2s timeout so a single dropped packet or a slow
+    # device (ESPHome, IoT) doesn't flap a node offline. Success = any reply.
+    #
+    # -W flag units differ by OS:
+    #   Linux:   seconds        (-W 2    = 2s)
+    #   macOS:   milliseconds   (-W 2000 = 2s)
+    #   Windows: -w in ms       (-w 2000 = 2s)
+    #
+    # IPv6-only hosts (e.g. Alexa) never answer IPv4 ping, so target the right
+    # stack: macOS ships a separate ping6; Linux/Windows take a family flag.
+    # `--` separates options from the host so a hostname starting with `-` can't
+    # be parsed as a flag (IPv6 literals can't start with `-`, so skip it there).
+    ipv6 = _is_ipv6(host)
     if sys.platform == "win32":
-        args = ["ping", "-n", "1", "-w", "1000", host]
+        family = ["-6"] if ipv6 else ["-4"]
+        args = ["ping", *family, "-n", "2", "-w", "2000", host]
+    elif sys.platform == "darwin":
+        args = (
+            ["ping6", "-c", "2", host]
+            if ipv6
+            else ["ping", "-c", "2", "-W", "2000", "--", host]
+        )
     else:
-        # `--` separates options from the host so a hostname starting with `-`
-        # can't be parsed as a flag.
-        args = ["ping", "-c", "1", "-W", "1", "--", host]
+        family = ["-6"] if ipv6 else []
+        args = ["ping", *family, "-c", "2", "-W", "2", "--", host]
     proc = await asyncio.create_subprocess_exec(
         *args,
         stdout=asyncio.subprocess.DEVNULL,
@@ -250,3 +278,97 @@ async def _tcp_connect(host: str, port: int) -> bool:
         return True
     except (TimeoutError, OSError, socket.gaierror):
         return False
+
+
+# --- Per-service status checks ---
+
+# Ports that are not HTTP/web. These get NO status check — a service here stays
+# grey (unknown) rather than going red. An open TCP socket doesn't prove the
+# service is healthy, and a closed one flaps red misleadingly (e.g. SSH on a
+# box that simply firewalls 22). Only HTTP(S)-reachable services are checked.
+_NON_HTTP_PORTS = frozenset({
+    22, 21, 23, 25, 465, 587, 53, 110, 143, 993, 995, 389, 636, 445, 514,
+    1433, 3306, 5432, 5672, 6379, 9092, 11211, 27017, 27018,
+})
+_HTTPS_PORTS = frozenset({443, 8443})
+
+
+def _service_host(host: str) -> str:
+    """Bracket bare IPv6 literals for use in a URL."""
+    return f"[{host}]" if _is_ipv6(host) else host
+
+
+async def check_service(
+    svc: dict[str, Any],
+    host: str | None,
+    allowed_networks: list[ipaddress.IPv4Network | ipaddress.IPv6Network] | None = None,
+) -> str:
+    """Check a single service. Returns 'online' | 'offline' | 'unknown'.
+
+    Only HTTP(S)-reachable services get a real check (an HTTP GET). Everything
+    else — SSH, databases, mail, DNS, raw TCP, UDP, port-less — stays 'unknown'
+    so it keeps its category colour instead of flashing red. An open TCP socket
+    doesn't prove a non-web service is healthy, so we don't pretend it does.
+
+    The same SSRF guard as node checks applies: a host that resolves to an
+    unsafe address outside the configured scan ranges is treated as offline.
+    """
+    if not host or host.startswith("-"):
+        return "unknown"
+    if str(svc.get("protocol", "")).lower() == "udp":
+        return "unknown"
+
+    port = svc.get("port")
+    port = int(port) if isinstance(port, int) or (
+        isinstance(port, str) and port.isdigit()
+    ) else None
+
+    # Non-HTTP ports (SSH 22, DB, mail, …) are never checked — keep them grey.
+    if port is not None and port in _NON_HTTP_PORTS:
+        return "unknown"
+
+    name = str(svc.get("service_name", "")).lower()
+    is_web = port is not None or "http" in name
+    if not is_web:
+        return "unknown"
+
+    if not _host_is_allowed(_extract_host(host) or host, allowed_networks or []):
+        return "offline"
+
+    try:
+        scheme = "https" if (
+            (port is not None and port in _HTTPS_PORTS)
+            or "https" in name
+            or "ssl" in name
+            or "tls" in name
+        ) else "http"
+        url_host = _service_host(host)
+        url = f"{scheme}://{url_host}" + (f":{port}" if port is not None else "")
+        return "online" if await _http_get(url, verify=False) else "offline"
+    except Exception as exc:
+        _LOGGER.debug("Service check failed for %s:%s (%s)", host, port, exc)
+        return "offline"
+
+
+async def check_services(
+    host: str | None,
+    services: list[dict[str, Any]],
+    allowed_networks: list[ipaddress.IPv4Network | ipaddress.IPv6Network] | None = None,
+    concurrency: int = 10,
+) -> list[dict[str, Any]]:
+    """Check every service against host concurrently (bounded).
+
+    Returns a list of {port, protocol, status} dicts, one per input service.
+    """
+    sem = asyncio.Semaphore(concurrency)
+
+    async def _one(svc: dict[str, Any]) -> dict[str, Any]:
+        async with sem:
+            status = await check_service(svc, host, allowed_networks)
+        return {
+            "port": svc.get("port"),
+            "protocol": svc.get("protocol"),
+            "status": status,
+        }
+
+    return await asyncio.gather(*[_one(s) for s in services]) if services else []

--- a/custom_components/homelable/translations/en.json
+++ b/custom_components/homelable/translations/en.json
@@ -24,7 +24,9 @@
           "scan_ranges": "Network ranges (CIDR, comma-separated)",
           "scan_interval": "Scan interval (seconds)",
           "status_interval": "Status check interval (seconds)",
-          "zigbee_base_topic": "Zigbee2MQTT base topic"
+          "zigbee_base_topic": "Zigbee2MQTT base topic",
+          "service_check_enabled": "Enable per-service status checks",
+          "service_check_interval": "Service check interval (seconds)"
         }
       }
     }

--- a/custom_components/homelable/translations/fr.json
+++ b/custom_components/homelable/translations/fr.json
@@ -24,7 +24,9 @@
           "scan_ranges": "Plages réseau (CIDR, séparées par des virgules)",
           "scan_interval": "Intervalle de scan (secondes)",
           "status_interval": "Intervalle de vérification d'état (secondes)",
-          "zigbee_base_topic": "Topic de base Zigbee2MQTT"
+          "zigbee_base_topic": "Topic de base Zigbee2MQTT",
+          "service_check_enabled": "Activer la vérification d'état par service",
+          "service_check_interval": "Intervalle de vérification des services (secondes)"
         }
       }
     }

--- a/custom_components/homelable/websocket.py
+++ b/custom_components/homelable/websocket.py
@@ -8,7 +8,7 @@ from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from .const import DOMAIN, SCAN_SIGNAL
+from .const import DOMAIN, SCAN_SIGNAL, SERVICE_STATUS_SIGNAL
 from .zigbee import ZigbeeMqttNotReadyError
 
 
@@ -31,6 +31,7 @@ def async_register_websocket_commands(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, ws_scan_clear)
     websocket_api.async_register_command(hass, ws_status_get)
     websocket_api.async_register_command(hass, ws_status_subscribe)
+    websocket_api.async_register_command(hass, ws_service_status_subscribe)
     websocket_api.async_register_command(hass, ws_scan_subscribe)
     websocket_api.async_register_command(hass, ws_scan_approve_batch)
     websocket_api.async_register_command(hass, ws_scan_hide_batch)
@@ -399,6 +400,33 @@ def ws_scan_subscribe(
         connection.send_message(websocket_api.event_message(msg["id"], payload))
 
     unsub = async_dispatcher_connect(hass, SCAN_SIGNAL, _forward)
+    connection.subscriptions[msg["id"]] = unsub
+    connection.send_result(msg["id"])
+
+
+@websocket_api.websocket_command(
+    {vol.Required("type"): "homelable/service_status/subscribe"}
+)
+@callback
+def ws_service_status_subscribe(
+    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
+) -> None:
+    """Push per-service status results as the coordinator computes them.
+
+    Each event is {node_id, services: [{port, protocol, status}], checked_at}.
+    Independent of the node-status subscription; only fires when per-service
+    checks are enabled in the options flow.
+    """
+    coord = _coordinator(hass)
+    if coord is None:
+        _send_not_setup(connection, msg["id"])
+        return
+
+    @callback
+    def _forward(payload: dict[str, Any]) -> None:
+        connection.send_message(websocket_api.event_message(msg["id"], payload))
+
+    unsub = async_dispatcher_connect(hass, SERVICE_STATUS_SIGNAL, _forward)
     connection.subscriptions[msg["id"]] = unsub
     connection.send_result(msg["id"])
 

--- a/frontend-src/src/api/ha.ts
+++ b/frontend-src/src/api/ha.ts
@@ -253,6 +253,20 @@ export async function subscribeStatus(
   return wsSubscribe<StatusUpdate>('homelable/status/subscribe', cb)
 }
 
+// ─── Per-service status subscription ────────────────────────────────────────
+
+export interface ServiceStatusUpdate {
+  node_id: string
+  services: Array<{ port?: number; protocol?: string; status: 'online' | 'offline' | 'unknown' }>
+  checked_at?: string
+}
+
+export async function subscribeServiceStatus(
+  cb: (update: ServiceStatusUpdate) => void
+): Promise<() => void> {
+  return wsSubscribe<ServiceStatusUpdate>('homelable/service_status/subscribe', cb)
+}
+
 // ─── Scan event subscription (progressive scan) ─────────────────────────────
 
 export type ScanEvent =

--- a/frontend-src/src/components/canvas/__tests__/BaseNode.test.tsx
+++ b/frontend-src/src/components/canvas/__tests__/BaseNode.test.tsx
@@ -20,7 +20,10 @@ vi.mock('@/stores/themeStore', () => ({
 }))
 
 vi.mock('@/stores/canvasStore', () => ({
-  useCanvasStore: (sel: (s: { hideIp: boolean }) => unknown) => sel({ hideIp: false }),
+  useCanvasStore: (sel: (s: { hideIp: boolean; serviceStatuses: Record<string, string> }) => unknown) =>
+    sel({ hideIp: false, serviceStatuses: {} }),
+  serviceStatusKey: (nodeId: string, port?: number, protocol?: string) =>
+    `${nodeId}:${port ?? ''}/${protocol ?? ''}`,
 }))
 
 vi.mock('@/utils/themes', () => ({

--- a/frontend-src/src/components/canvas/nodes/BaseNode.tsx
+++ b/frontend-src/src/components/canvas/nodes/BaseNode.tsx
@@ -8,7 +8,7 @@ import { NodeIcon } from '@/components/ui/NodeIcon'
 import { resolvePropertyIcon } from '@/utils/propertyIcons'
 import { useThemeStore } from '@/stores/themeStore'
 import { THEMES } from '@/utils/themes'
-import { useCanvasStore } from '@/stores/canvasStore'
+import { useCanvasStore, serviceStatusKey } from '@/stores/canvasStore'
 import { maskIp, primaryIp, splitIps } from '@/utils/maskIp'
 import { bottomHandleId, bottomHandlePositions, clampBottomHandles } from '@/utils/handleUtils'
 import { getServiceUrl } from '@/utils/serviceUrl'
@@ -31,6 +31,7 @@ export function BaseNode({ id, data, selected, icon: typeIcon, width, height }: 
 
   const activeTheme = useThemeStore((s) => s.activeTheme)
   const hideIp = useCanvasStore((s) => s.hideIp)
+  const serviceStatuses = useCanvasStore((s) => s.serviceStatuses)
   const theme = THEMES[activeTheme]
 
   const resolvedIcon = resolveNodeIcon(typeIcon, data.custom_icon)
@@ -152,6 +153,7 @@ export function BaseNode({ id, data, selected, icon: typeIcon, width, height }: 
           <div className="flex flex-col gap-1 px-2.5 py-1.5 overflow-hidden">
             {services.map((svc, idx) => {
               const url = getServiceUrl(svc, serviceHost)
+              const svcOffline = serviceStatuses[serviceStatusKey(id, svc.port, svc.protocol)] === 'offline'
               const row = (
                 <div
                   className="nodrag flex items-center justify-between gap-2 px-1.5 py-1 rounded text-[10px] min-w-0 overflow-hidden"
@@ -164,7 +166,7 @@ export function BaseNode({ id, data, selected, icon: typeIcon, width, height }: 
                     {/* LEFT: service name */}
                     <span
                       className="font-medium truncate"
-                      style={{ minWidth: 0 }}
+                      style={{ minWidth: 0, color: svcOffline ? '#f85149' : undefined }}
                       title={svc.service_name}
                     >
                       {svc.service_name}

--- a/frontend-src/src/components/panels/DetailPanel.tsx
+++ b/frontend-src/src/components/panels/DetailPanel.tsx
@@ -2,8 +2,8 @@ import { createElement, useState } from 'react'
 import { X, Edit, Trash2, ExternalLink, Plus, Pencil, Layers, Ungroup, Eye, EyeOff } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { useCanvasStore } from '@/stores/canvasStore'
-import { NODE_TYPE_LABELS, STATUS_COLORS, type ServiceInfo, type NodeData, type NodeProperty } from '@/types'
+import { useCanvasStore, serviceStatusKey } from '@/stores/canvasStore'
+import { NODE_TYPE_LABELS, STATUS_COLORS, type ServiceInfo, type ServiceStatus, type NodeData, type NodeProperty } from '@/types'
 import { getServiceUrl } from '@/utils/serviceUrl'
 import { primaryIp } from '@/utils/maskIp'
 import { PROPERTY_ICONS, PROPERTY_ICON_NAMES, resolvePropertyIcon } from '@/utils/propertyIcons'
@@ -21,6 +21,7 @@ const EMPTY_PROP: PropForm = { key: '', value: '', icon: null, visible: true }
 
 export function DetailPanel({ onEdit }: DetailPanelProps) {
   const { nodes, selectedNodeId, selectedNodeIds, setSelectedNode, deleteNode, updateNode, snapshotHistory, createGroup, ungroup } = useCanvasStore()
+  const serviceStatuses = useCanvasStore((s) => s.serviceStatuses)
 
   const [addingForNode, setAddingForNode] = useState<string | null>(null)
   const [newSvc, setNewSvc] = useState<SvcForm>(EMPTY_FORM)
@@ -299,7 +300,7 @@ export function DetailPanel({ onEdit }: DetailPanelProps) {
               editingIndex === i ? (
                 <ServiceForm key={`edit-${i}`} form={editSvc} onChange={setEditSvc} onConfirm={handleSaveEdit} onCancel={() => setEditingFor(null)} confirmLabel="Save" autoFocus />
               ) : (
-                <ServiceBadge key={`${svc.port ?? 'host'}-${svc.protocol}-${svc.path ?? ''}-${i}`} svc={svc} host={host} onEdit={() => handleStartEdit(i)} onRemove={() => handleRemoveService(i)} />
+                <ServiceBadge key={`${svc.port ?? 'host'}-${svc.protocol}-${svc.path ?? ''}-${i}`} svc={svc} host={host} status={serviceStatuses[serviceStatusKey(node.id, svc.port, svc.protocol)]} onEdit={() => handleStartEdit(i)} onRemove={() => handleRemoveService(i)} />
               )
             )}
           </div>
@@ -658,9 +659,13 @@ const CATEGORY_COLORS: Record<string, string> = {
   web: '#00d4ff', database: '#a855f7', monitoring: '#39d353', storage: '#e3b341', security: '#f85149', remote: '#8b949e',
 }
 
-function ServiceBadge({ svc, host, onEdit, onRemove }: { svc: ServiceInfo; host?: string; onEdit: () => void; onRemove: () => void }) {
+function ServiceBadge({ svc, host, status, onEdit, onRemove }: { svc: ServiceInfo; host?: string; status?: ServiceStatus; onEdit: () => void; onRemove: () => void }) {
   const url = getServiceUrl(svc, host)
-  const color = CATEGORY_COLORS[svc.category ?? ''] ?? '#8b949e'
+  // Manually-added services carry no category, so they fell back to grey even
+  // when they're reachable HTTP/HTTPS. Treat any resolvable web URL as `web`.
+  const categoryColor = CATEGORY_COLORS[svc.category ?? ''] ?? (url ? CATEGORY_COLORS.web : '#8b949e')
+  // A live offline service overrides the category colour with red.
+  const color = status === 'offline' ? '#f85149' : categoryColor
   const pathLabel = svc.path?.trim() ? svc.path.trim() : ''
 
   return (

--- a/frontend-src/src/hooks/useStatusPolling.ts
+++ b/frontend-src/src/hooks/useStatusPolling.ts
@@ -7,14 +7,20 @@
  * Real subscription will replace polling once the backend pushes updates.
  */
 import { useEffect } from 'react'
-import { subscribeStatus, type StatusUpdate } from '@/api/ha'
+import {
+  subscribeStatus,
+  subscribeServiceStatus,
+  type StatusUpdate,
+  type ServiceStatusUpdate,
+} from '@/api/ha'
 import { useCanvasStore } from '@/stores/canvasStore'
 
 export function useStatusPolling() {
-  const { updateNode } = useCanvasStore()
+  const { updateNode, setServiceStatuses } = useCanvasStore()
 
   useEffect(() => {
     let unsubscribe: (() => void) | null = null
+    let unsubscribeService: (() => void) | null = null
     let cancelled = false
 
     void subscribeStatus((update: StatusUpdate) => {
@@ -30,9 +36,19 @@ export function useStatusPolling() {
       else unsubscribe = un
     })
 
+    // Per-service overlay — only emits when service checks are enabled in options.
+    void subscribeServiceStatus((update: ServiceStatusUpdate) => {
+      if (cancelled || !update.node_id || !update.services) return
+      setServiceStatuses(update.node_id, update.services)
+    }).then((un) => {
+      if (cancelled) un()
+      else unsubscribeService = un
+    })
+
     return () => {
       cancelled = true
       if (unsubscribe) unsubscribe()
+      if (unsubscribeService) unsubscribeService()
     }
-  }, [updateNode])
+  }, [updateNode, setServiceStatuses])
 }

--- a/frontend-src/src/stores/__tests__/canvasStore.test.ts
+++ b/frontend-src/src/stores/__tests__/canvasStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { useCanvasStore } from '@/stores/canvasStore'
+import { useCanvasStore, serviceStatusKey } from '@/stores/canvasStore'
 import type { Node, Edge } from '@xyflow/react'
 import type { NodeData, EdgeData } from '@/types'
 
@@ -900,5 +900,33 @@ describe('canvasStore — custom style apply', () => {
     expect(ns.data.custom_colors?.border).toBeUndefined()
     expect(e.data?.custom_color).toBe('#aabbcc')
     expect(useCanvasStore.getState().hasUnsavedChanges).toBe(true)
+  })
+})
+
+describe('canvasStore — per-service status overlay', () => {
+  beforeEach(() => {
+    useCanvasStore.setState({ serviceStatuses: {}, hasUnsavedChanges: false })
+  })
+
+  it('serviceStatusKey is stable for the same node/port/protocol', () => {
+    expect(serviceStatusKey('n1', 80, 'tcp')).toBe('n1:80/tcp')
+    expect(serviceStatusKey('n1', undefined, undefined)).toBe('n1:/')
+  })
+
+  it('setServiceStatuses stores statuses keyed per node+service', () => {
+    useCanvasStore.getState().setServiceStatuses('n1', [
+      { port: 80, protocol: 'tcp', status: 'offline' },
+      { port: 443, protocol: 'tcp', status: 'online' },
+    ])
+    const { serviceStatuses } = useCanvasStore.getState()
+    expect(serviceStatuses[serviceStatusKey('n1', 80, 'tcp')]).toBe('offline')
+    expect(serviceStatuses[serviceStatusKey('n1', 443, 'tcp')]).toBe('online')
+  })
+
+  it('overlay never marks the canvas dirty (stays out of saves)', () => {
+    useCanvasStore.getState().setServiceStatuses('n1', [
+      { port: 80, protocol: 'tcp', status: 'offline' },
+    ])
+    expect(useCanvasStore.getState().hasUnsavedChanges).toBe(false)
   })
 })

--- a/frontend-src/src/stores/canvasStore.ts
+++ b/frontend-src/src/stores/canvasStore.ts
@@ -9,12 +9,16 @@ import {
   applyEdgeChanges,
   addEdge,
 } from '@xyflow/react'
-import type { NodeData, EdgeData, NodeType, EdgeType, NodeTypeStyle, EdgeTypeStyle, CustomStyleDef } from '@/types'
+import type { NodeData, EdgeData, NodeType, EdgeType, NodeTypeStyle, EdgeTypeStyle, CustomStyleDef, ServiceStatus } from '@/types'
 import { generateUUID } from '@/utils/uuid'
 import { normalizeHandle, removedBottomHandleIds } from '@/utils/handleUtils'
 import { applyOpacity } from '@/utils/colorUtils'
 
 type HistoryEntry = { nodes: Node<NodeData>[]; edges: Edge<EdgeData>[] }
+
+/** Key for the live per-service status overlay. */
+export const serviceStatusKey = (nodeId: string, port?: number, protocol?: string): string =>
+  `${nodeId}:${port ?? ''}/${protocol ?? ''}`
 
 interface CanvasState {
   nodes: Node<NodeData>[]
@@ -23,6 +27,8 @@ interface CanvasState {
   selectedNodeId: string | null
   selectedNodeIds: string[]
   scanEventTs: number
+  // Live per-service status overlay (not persisted), keyed via serviceStatusKey.
+  serviceStatuses: Record<string, ServiceStatus>
 
   // History
   past: HistoryEntry[]
@@ -60,6 +66,7 @@ interface CanvasState {
   fitViewPending: boolean
   clearFitViewPending: () => void
   notifyScanDeviceFound: () => void
+  setServiceStatuses: (nodeId: string, statuses: { port?: number; protocol?: string; status: ServiceStatus }[]) => void
   hideIp: boolean
   toggleHideIp: () => void
   applyTypeNodeStyle: (nodeType: NodeType, style: NodeTypeStyle) => void
@@ -77,6 +84,7 @@ export const useCanvasStore = create<CanvasState>((set) => ({
   editingTextId: null,
   hideIp: false,
   scanEventTs: 0,
+  serviceStatuses: {},
   fitViewPending: false,
 
   past: [],
@@ -485,6 +493,16 @@ export const useCanvasStore = create<CanvasState>((set) => ({
   markUnsaved: () => set({ hasUnsavedChanges: true }),
 
   notifyScanDeviceFound: () => set({ scanEventTs: Date.now() }),
+
+  setServiceStatuses: (nodeId, statuses) =>
+    set((state) => {
+      // Live overlay only — never touches node data, so it stays out of saves.
+      const next = { ...state.serviceStatuses }
+      for (const s of statuses) {
+        next[serviceStatusKey(nodeId, s.port, s.protocol)] = s.status
+      }
+      return { serviceStatuses: next }
+    }),
 
   toggleHideIp: () => set((s) => ({ hideIp: !s.hideIp })),
 

--- a/frontend-src/src/types/index.ts
+++ b/frontend-src/src/types/index.ts
@@ -78,6 +78,8 @@ export interface ServiceInfo {
   category?: string
 }
 
+export type ServiceStatus = 'online' | 'offline' | 'unknown'
+
 export interface NodeProperty {
   key: string
   value: string

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,6 +1,8 @@
 """Test the Homelable config flow."""
 from unittest.mock import patch
 
+import pytest
+import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -9,6 +11,8 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.homelable.const import (
     CONF_SCAN_INTERVAL,
     CONF_SCAN_RANGES,
+    CONF_SERVICE_CHECK_ENABLED,
+    CONF_SERVICE_CHECK_INTERVAL,
     CONF_STATUS_INTERVAL,
     DOMAIN,
 )
@@ -48,3 +52,58 @@ async def test_single_instance_only(hass: HomeAssistant) -> None:
     )
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
+
+
+async def test_options_flow_saves_service_check_settings(hass: HomeAssistant) -> None:
+    """The options flow exposes and persists per-service check settings."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Homelable",
+        data={
+            CONF_SCAN_RANGES: "192.168.1.0/24",
+            CONF_SCAN_INTERVAL: 3600,
+            CONF_STATUS_INTERVAL: 60,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    result2 = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            CONF_SCAN_RANGES: "192.168.1.0/24",
+            CONF_SCAN_INTERVAL: 3600,
+            CONF_STATUS_INTERVAL: 60,
+            CONF_SERVICE_CHECK_ENABLED: True,
+            CONF_SERVICE_CHECK_INTERVAL: 120,
+        },
+    )
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["data"][CONF_SERVICE_CHECK_ENABLED] is True
+    assert result2["data"][CONF_SERVICE_CHECK_INTERVAL] == 120
+
+
+async def test_options_flow_rejects_sub_minimum_interval(hass: HomeAssistant) -> None:
+    """Service-check interval below the minimum is rejected."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Homelable",
+        data={CONF_SCAN_RANGES: "192.168.1.0/24"},
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    with pytest.raises(vol.Invalid):
+        await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {
+                CONF_SCAN_RANGES: "192.168.1.0/24",
+                CONF_SCAN_INTERVAL: 3600,
+                CONF_STATUS_INTERVAL: 60,
+                CONF_SERVICE_CHECK_ENABLED: True,
+                CONF_SERVICE_CHECK_INTERVAL: 5,
+            },
+        )

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -537,3 +537,85 @@ async def test_trigger_scan_updates_existing_pending_in_place(coord) -> None:  #
     assert len(devices) == 1
     assert devices[0]["mac"] == "AA:BB:CC:11:22:33"
     assert devices[0]["hostname"] == "now-known.lan"
+
+
+# --- Per-service status checks (#196 follow-up) ---
+
+
+@pytest.mark.asyncio
+async def test_service_check_getters_default_disabled(coord) -> None:  # noqa: ANN001
+    assert coord.get_service_check_enabled() is False
+    assert coord.get_service_check_interval() == 300
+
+
+@pytest.mark.asyncio
+async def test_service_check_interval_floored_at_minimum(hass) -> None:  # noqa: ANN001
+    entry = _mock_entry()
+    entry.options = {"service_check_enabled": True, "service_check_interval": 5}
+    c = HomelableCoordinator(hass, entry)
+    assert c.get_service_check_enabled() is True
+    assert c.get_service_check_interval() == 30  # MIN_SERVICE_CHECK_INTERVAL
+
+
+@pytest.mark.asyncio
+async def test_start_service_checks_noop_when_disabled(coord) -> None:  # noqa: ANN001
+    coord.async_start_service_checks()
+    assert coord._service_check_unsub is None
+
+
+@pytest.mark.asyncio
+async def test_start_stop_service_checks_when_enabled(hass) -> None:  # noqa: ANN001
+    entry = _mock_entry()
+    entry.options = {"service_check_enabled": True}
+    c = HomelableCoordinator(hass, entry)
+    c.async_start_service_checks()
+    assert c._service_check_unsub is not None
+    c.async_stop_service_checks()
+    assert c._service_check_unsub is None
+
+
+@pytest.mark.asyncio
+async def test_run_service_checks_dispatches_per_node(hass) -> None:  # noqa: ANN001
+    from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+    from custom_components.homelable.const import SERVICE_STATUS_SIGNAL
+
+    entry = _mock_entry()
+    entry.options = {"service_check_enabled": True}
+    c = HomelableCoordinator(hass, entry)
+    await c.save_canvas(
+        {
+            "nodes": [
+                {
+                    "id": "n1",
+                    "ip": "192.168.1.5",
+                    "services": [{"port": 80, "protocol": "tcp", "service_name": "http"}],
+                },
+                {"id": "n2", "ip": "192.168.1.6", "services": []},  # skipped: no services
+            ],
+            "edges": [],
+            "viewport": {"x": 0, "y": 0, "zoom": 1},
+        }
+    )
+
+    received: list[dict] = []
+    unsub = async_dispatcher_connect(
+        hass, SERVICE_STATUS_SIGNAL, lambda p: received.append(p)
+    )
+    with patch(
+        "custom_components.homelable.coordinator.status_checker.check_services",
+        AsyncMock(return_value=[{"port": 80, "protocol": "tcp", "status": "offline"}]),
+    ) as mock:
+        await c._run_service_checks()
+        await hass.async_block_till_done()
+    unsub()
+
+    assert mock.called
+    # Only the node with services is checked / dispatched.
+    assert len(received) == 1
+    assert received[0]["node_id"] == "n1"
+    assert received[0]["services"] == [
+        {"port": 80, "protocol": "tcp", "status": "offline"}
+    ]
+    # host derived from the node's first IP.
+    assert mock.call_args.args[0] == "192.168.1.5"

--- a/tests/test_status_checker.py
+++ b/tests/test_status_checker.py
@@ -140,3 +140,93 @@ async def test_check_exception_returns_offline() -> None:
     ):
         result = await status_checker.check_node("ping", None, "10.0.0.1")
     assert result == {"status": "offline", "response_time_ms": None}
+
+
+# --- IPv6 detection (#196 B2) ---
+
+def test_is_ipv6_detects_literals() -> None:
+    assert status_checker._is_ipv6("fe80::1")
+    assert status_checker._is_ipv6("[2001:db8::1]")
+    assert not status_checker._is_ipv6("192.168.1.1")
+    assert not status_checker._is_ipv6("example.com")
+
+
+# --- Per-service status checks (#196 follow-up) ---
+
+@pytest.mark.asyncio
+async def test_check_service_web_online() -> None:
+    """A web port that answers HTTP → online."""
+    svc = {"port": 8080, "protocol": "tcp", "service_name": "http"}
+    with patch.object(
+        status_checker, "_http_get", AsyncMock(return_value=True)
+    ) as mock:
+        status = await status_checker.check_service(svc, "10.0.0.5")
+    assert status == "online"
+    assert mock.call_args.args[0] == "http://10.0.0.5:8080"
+
+
+@pytest.mark.asyncio
+async def test_check_service_web_offline() -> None:
+    svc = {"port": 8080, "protocol": "tcp", "service_name": "http"}
+    with patch.object(status_checker, "_http_get", AsyncMock(return_value=False)):
+        status = await status_checker.check_service(svc, "10.0.0.5")
+    assert status == "offline"
+
+
+@pytest.mark.asyncio
+async def test_check_service_https_port_uses_https_scheme() -> None:
+    svc = {"port": 443, "protocol": "tcp", "service_name": "web"}
+    with patch.object(
+        status_checker, "_http_get", AsyncMock(return_value=True)
+    ) as mock:
+        await status_checker.check_service(svc, "10.0.0.5")
+    assert mock.call_args.args[0] == "https://10.0.0.5:443"
+
+
+@pytest.mark.asyncio
+async def test_check_service_non_http_port_is_unknown() -> None:
+    """SSH and other non-web ports are never probed — stay grey."""
+    svc = {"port": 22, "protocol": "tcp", "service_name": "ssh"}
+    with patch.object(status_checker, "_http_get", AsyncMock()) as mock:
+        status = await status_checker.check_service(svc, "10.0.0.5")
+    assert status == "unknown"
+    mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_check_service_udp_is_unknown() -> None:
+    svc = {"port": 53, "protocol": "udp", "service_name": "dns"}
+    status = await status_checker.check_service(svc, "10.0.0.5")
+    assert status == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_check_service_portless_non_web_is_unknown() -> None:
+    svc = {"protocol": "tcp", "service_name": "smtp"}
+    status = await status_checker.check_service(svc, "10.0.0.5")
+    assert status == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_check_service_no_host_is_unknown() -> None:
+    svc = {"port": 80, "protocol": "tcp", "service_name": "http"}
+    assert await status_checker.check_service(svc, None) == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_check_services_returns_one_row_per_service() -> None:
+    services = [
+        {"port": 80, "protocol": "tcp", "service_name": "http"},
+        {"port": 22, "protocol": "tcp", "service_name": "ssh"},
+    ]
+    with patch.object(status_checker, "_http_get", AsyncMock(return_value=True)):
+        rows = await status_checker.check_services("10.0.0.5", services)
+    assert rows == [
+        {"port": 80, "protocol": "tcp", "status": "online"},
+        {"port": 22, "protocol": "tcp", "status": "unknown"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_check_services_empty() -> None:
+    assert await status_checker.check_services("10.0.0.5", []) == []

--- a/tests/test_status_checker_security.py
+++ b/tests/test_status_checker_security.py
@@ -127,3 +127,25 @@ async def test_check_node_tcp_rejects_link_local_by_default() -> None:
         )
     assert result["status"] == "offline"
     mock.assert_not_awaited()
+
+
+# ─── Per-service checks honor the host filter ────────────────────────────────
+
+
+async def test_check_service_blocks_loopback_without_allowlist() -> None:
+    """A web service on loopback is reported offline, never probed."""
+    svc = {"port": 80, "protocol": "tcp", "service_name": "http"}
+    with patch.object(status_checker, "_http_get", AsyncMock(return_value=True)) as mock:
+        status = await status_checker.check_service(svc, "127.0.0.1", [])
+    assert status == "offline"
+    mock.assert_not_awaited()
+
+
+async def test_check_service_allows_loopback_when_in_scan_range() -> None:
+    svc = {"port": 80, "protocol": "tcp", "service_name": "http"}
+    with patch.object(status_checker, "_http_get", AsyncMock(return_value=True)) as mock:
+        status = await status_checker.check_service(
+            svc, "127.0.0.1", [_net("127.0.0.0/8")]
+        )
+    assert status == "online"
+    mock.assert_awaited_once()

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -293,6 +293,29 @@ async def test_scan_subscribe_forwards_dispatcher_events(
     assert msg["event"] == payload
 
 
+async def test_service_status_subscribe_pushes_events(
+    hass: HomeAssistant, hass_ws_client, setup_ws  # noqa: ANN001
+) -> None:
+    from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+    from custom_components.homelable.const import SERVICE_STATUS_SIGNAL
+
+    client = await hass_ws_client(hass)
+    await client.send_json({"id": 1, "type": "homelable/service_status/subscribe"})
+    ack = await client.receive_json()
+    assert ack["success"] is True
+
+    payload = {
+        "node_id": "n1",
+        "services": [{"port": 80, "protocol": "tcp", "status": "offline"}],
+        "checked_at": "2024-01-01T00:00:00+00:00",
+    }
+    async_dispatcher_send(hass, SERVICE_STATUS_SIGNAL, payload)
+    msg = await client.receive_json()
+    assert msg["type"] == "event"
+    assert msg["event"] == payload
+
+
 # ─── Not setup ───────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Port of standalone [PR #198](https://github.com/Pouzor/homelable/pull/198) (issue #196).

## Per-service status checks (optional, off by default)
Live status per service, independent of node checks.
- **Backend:** `check_service` / `check_services` — HTTP(S) GET for web ports, everything else (SSH, DBs, mail, UDP, port-less) stays `unknown` so it keeps its category colour instead of flashing red. Reuses the existing SSRF host filter.
- **Coordinator:** independent `async_track_time_interval` job dispatches per-node `SERVICE_STATUS_SIGNAL`; enabled/interval getters + node-host helper. Started on setup, cancelled on unload (reload-on-options-change picks up new settings).
- **WS:** new `homelable/service_status/subscribe`.
- **Config:** toggle + interval in the **options flow** (hacs has no SettingsModal), default 300s, min 30s.
- **Frontend:** non-persisted `serviceStatuses` overlay in `canvasStore` (never round-trips through canvas save), `subscribeServiceStatus` + `useStatusPolling` wiring. Offline service → red `#f85149` in DetailPanel badges and canvas node rows.

## #196 bug fixes (folded in)
- **B1** — `ping` now sends 2 probes / ~2s, so a single dropped packet no longer flaps a node offline.
- **B2** — IPv6-only hosts (e.g. Alexa) pinged on the right stack (`ping6` / `-6`).
- **B3** — manually added web services fall back to the `web` colour instead of grey.

## Adaptations vs standalone (expected drift)
- APScheduler job → HA `async_track_time_interval`
- FastAPI WS broadcast → HA dispatcher + WS subscribe
- `SettingsModal` → options flow
- WS `_drop` idempotency fix is N/A (HA owns the socket)
- Service checks also inherit the hacs SSRF host filter, which the standalone lacks

## Verification
- Backend: `ruff` ✓, 164 pytest ✓
- Frontend: 860 vitest ✓, `tsc --noEmit` ✓, eslint clean on changed files, `build:ha` ✓

New tests: `check_service`/`check_services` + IPv6 detection, the SSRF guard on service checks, coordinator getters + service-check dispatch + timer lifecycle, options-flow fields + validation, WS `service_status` subscribe, and the canvasStore overlay.

Off by default — no behaviour change until enabled in the options flow.