### PR TITLE
fix(layout): reserve real size for container nodes in auto-layout

### DIFF
--- a/frontend-src/src/utils/__tests__/layout.test.ts
+++ b/frontend-src/src/utils/__tests__/layout.test.ts
@@ -102,6 +102,32 @@ describe('applyDagreLayout', () => {
     expect(frigate.position.y).toBeGreaterThan(proxmox.position.y)
   })
 
+  it('does not overlap sized container nodes (groups) that carry no edges', () => {
+    // Regression: issue #10. Two grouped containers have explicit width/height
+    // but no edges, so Dagre stacks them on the same rank. With the wrong size
+    // (180x52) reserved, their real 400-wide boxes overlapped ("same stack").
+    function makeGroup(id: string): Node<NodeData> {
+      return {
+        id,
+        type: 'group',
+        position: { x: 0, y: 0 },
+        width: 400,
+        height: 300,
+        data: { type: 'group', label: id } as unknown as NodeData,
+      }
+    }
+    const nodes = [makeGroup('g1'), makeGroup('g2')]
+    const edges: Edge<EdgeData>[] = []
+
+    const result = applyDagreLayout(nodes, edges)
+    const g1 = result.find((n) => n.id === 'g1')!
+    const g2 = result.find((n) => n.id === 'g2')!
+
+    // Their 400-wide boxes must not overlap on the X axis.
+    const [leftBox, rightBox] = g1.position.x <= g2.position.x ? [g1, g2] : [g2, g1]
+    expect(rightBox.position.x).toBeGreaterThanOrEqual(leftBox.position.x + 400)
+  })
+
   it('places two switch nodes connected to each other at the same Y', () => {
     const nodes = [
       makeNode('router', 'router'),

--- a/frontend-src/src/utils/layout.ts
+++ b/frontend-src/src/utils/layout.ts
@@ -8,6 +8,18 @@ const NODE_HEIGHT = 52
 const PEER_TYPES = new Set(['proxmox', 'switch'])
 
 /**
+ * Real footprint Dagre should reserve for a top-level node.
+ * Container nodes (group, groupRect, resized proxmox) carry an explicit
+ * width/height — use it so Dagre doesn't overlap them. Plain device nodes
+ * have none, so fall back to the default node box.
+ */
+function nodeSize(node: Node<NodeData>): { w: number; h: number } {
+  const w = node.width ?? (node.type === 'proxmox' ? 300 : NODE_WIDTH)
+  const h = node.height ?? (node.type === 'proxmox' ? 200 : NODE_HEIGHT)
+  return { w, h }
+}
+
+/**
  * Find groups of peer nodes (same type, directly connected to each other)
  * using union-find. Returns a map: nodeId → groupId (the minimum nodeId in the group).
  */
@@ -77,8 +89,7 @@ export function applyDagreLayout(
   g.setGraph({ rankdir: 'TB', nodesep: 60, ranksep: 80 })
 
   for (const node of topLevel) {
-    const w = node.type === 'proxmox' ? (node.width ?? 300) : NODE_WIDTH
-    const h = node.type === 'proxmox' ? (node.height ?? 200) : NODE_HEIGHT
+    const { w, h } = nodeSize(node)
     g.setNode(node.id, { width: w, height: h })
   }
   for (const edge of edges) {
@@ -103,8 +114,7 @@ export function applyDagreLayout(
   const positions = new Map<string, { x: number; y: number; w: number; h: number }>()
   for (const node of topLevel) {
     const pos = g.node(node.id)
-    const w = node.type === 'proxmox' ? (node.width ?? 300) : NODE_WIDTH
-    const h = node.type === 'proxmox' ? (node.height ?? 200) : NODE_HEIGHT
+    const { w, h } = nodeSize(node)
     positions.set(node.id, { x: pos.x - w / 2, y: pos.y - h / 2, w, h })
   }
 


### PR DESCRIPTION
## Problem

Fixes #10 — running auto-layout after grouping devices places the groups on the same stack (overlapping).

## Root cause

Group / `groupRect` nodes carry an explicit `width`/`height`, but `applyDagreLayout` only treated `proxmox` as large — every other top-level node was reserved a fixed `180x52` box. Grouped containers also carry no edges, so Dagre dumps them all on the same rank. Reserving a tiny box for a 400-wide group meant neighbours were placed ~240px apart while actually 400+ wide → overlap.

## Fix

- Add a `nodeSize()` helper that uses a node's real `width`/`height` when present (group, groupRect, resized proxmox), falling back to the default box for plain device nodes.
- Use it in both the Dagre `setNode` pass and the position read-back.

## Test

- New regression test in `layout.test.ts`: two edgeless 400-wide group nodes must not overlap on the X axis.
- Full layout suite passes (6/6).